### PR TITLE
Extract code in cli-driver to handlers/ folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zli",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/handlers/clean-exit.handler.ts
+++ b/src/handlers/clean-exit.handler.ts
@@ -1,0 +1,7 @@
+import { Logger } from '../logger.service/logger';
+
+
+export async function cleanExit(exitCode: number, logger: Logger) {
+    await logger.flushLogs();
+    process.exit(exitCode);
+}

--- a/src/handlers/config.handler.ts
+++ b/src/handlers/config.handler.ts
@@ -1,0 +1,11 @@
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+import { LoggerConfigService } from '../logger-config.service/logger-config.service';
+import { cleanExit } from './clean-exit.handler';
+
+
+export async function configHandler(logger: Logger, configService: ConfigService, loggerConfigService: LoggerConfigService) {
+    logger.info(`You can edit your config here: ${configService.configPath()}`);
+    logger.info(`You can find your log files here: ${loggerConfigService.logPath()}`);
+    await cleanExit(0, logger);
+}

--- a/src/handlers/connect.handler.ts
+++ b/src/handlers/connect.handler.ts
@@ -1,0 +1,212 @@
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+import { SessionService, ConnectionService } from '../http.service/http.service';
+import { EnvironmentDetails, ConnectionState } from '../http.service/http.service.types';
+import { SessionState, TargetType } from '../types';
+import {
+    TargetSummary,
+    parsedTargetString,
+    parseTargetString,
+    checkTargetTypeAndStringPair,
+    getTableOfTargets,
+    targetStringExampleNoPath
+} from '../utils';
+import { ShellTerminal } from '../terminal/terminal';
+import { MixpanelService } from '../mixpanel.service/mixpanel.service';
+import { cleanExit } from './clean-exit.handler';
+
+import termsize from 'term-size';
+
+
+export async function connectHandler(
+    configService: ConfigService,
+    logger: Logger,
+    argv: any,
+    mixpanelService: MixpanelService,
+    dynamicConfigs: Promise<TargetSummary[]>,
+    ssmTargets: Promise<TargetSummary[]>,
+    sshTargets: Promise<TargetSummary[]>,
+    envs: Promise<EnvironmentDetails[]>,) {
+    const parsedTarget = await disambiguateTargetName(argv.targetType, argv.targetString, logger, dynamicConfigs, ssmTargets, sshTargets, envs);
+
+    // call list session
+    const sessionService = new SessionService(configService, logger);
+    const listSessions = await sessionService.ListSessions();
+
+    // space names are not unique, make sure to find the latest active one
+    const cliSpace = listSessions.sessions.filter(s => s.displayName === 'cli-space' && s.state == SessionState.Active); // TODO: cli-space name can be changed in config
+
+    // maybe make a session
+    let cliSessionId: string;
+    if(cliSpace.length === 0)
+    {
+        cliSessionId =  await sessionService.CreateSession('cli-space');
+    } else {
+        // there should only be 1 active 'cli-space' session
+        cliSessionId = cliSpace.pop().id;
+    }
+
+    // We do the following for ssh since we are required to pass
+    // in a user although it does not get read at any point
+    const targetUser = parsedTarget.type === TargetType.SSH ? 'ssh' : parsedTarget.user;
+
+    // make a new connection
+    const connectionService = new ConnectionService(configService, logger);
+    // if SSM user does not exist then resp.connectionId will throw a
+    // 'TypeError: Cannot read property 'connectionId' of undefined'
+    // so we need to catch and return undefined
+    const connectionId = await connectionService.CreateConnection(parsedTarget.type, parsedTarget.id, cliSessionId, targetUser).catch(() => undefined);
+
+    if(! connectionId)
+    {
+        logger.error('Connection creation failed');
+        if(parsedTarget.type !== TargetType.SSH)
+        {
+            const allSsmBasedTargets = (await ssmTargets).concat(await dynamicConfigs);
+            const targetEnvId = allSsmBasedTargets.filter(ssm => ssm.id == parsedTarget.id)[0].environmentId;
+            const targetEnvName = (await envs).filter(e => e.id == targetEnvId)[0].name;
+            logger.error(`You may not have a policy for targetUser ${parsedTarget.user} in environment ${targetEnvName}`);
+            logger.info('You can find SSM user policies in the web app');
+        } else {
+            logger.info('Please check your polices in the web app for this target and/or environment');
+        }
+
+        await cleanExit(1, logger);
+    }
+
+    // connect to target and run terminal
+    var terminal = new ShellTerminal(configService, connectionId);
+    try {
+        await terminal.start(termsize());
+    } catch (err) {
+        logger.error(`Error connecting to terminal: ${err.stack}`);
+        await cleanExit(1, logger);
+    }
+
+    mixpanelService.TrackNewConnection(parsedTarget.type);
+
+    // Terminal resize event logic
+    // https://nodejs.org/api/process.html#process_signal_events -> SIGWINCH
+    // https://github.com/nodejs/node/issues/16194
+    // https://nodejs.org/api/process.html#process_a_note_on_process_i_o
+    process.stdout.on(
+        'resize',
+        () => {
+            const resizeEvent = termsize();
+            terminal.resize(resizeEvent);
+        }
+    );
+
+    // If we detect a disconnection, close the connection immediately
+    terminal.terminalRunning.subscribe(
+        () => {},
+        async (error) => {
+            if(error)
+            {
+                logger.error(error);
+                logger.warn('Target may have gone offline or space/connection closed from another client');
+            }
+
+            terminal.dispose();
+
+            logger.debug('Cleaning up connection...');
+            const conn = await connectionService.GetConnection(connectionId);
+            // if connection not already closed
+            if(conn.state == ConnectionState.Open)
+                await connectionService.CloseConnection(connectionId);
+
+            logger.debug('Connection closed');
+
+            if(error)
+                await cleanExit(1, logger);
+
+            await cleanExit(0, logger);
+        },
+        () => {}
+    );
+
+    // To get 'keypress' events you need the following lines
+    // ref: https://nodejs.org/api/readline.html#readline_readline_emitkeypressevents_stream_interface
+    const readline = require('readline');
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+    process.stdin.on('keypress', (_, key) => terminal.writeString(key.sequence));
+}
+
+
+// Figure out target id based on target name and target type.
+// Also preforms error checking on target type and target string passed in
+async function disambiguateTargetName(
+    argvTargetType: string,
+    argvTargetString: string,
+    logger: Logger,
+    dynamicConfigs: Promise<TargetSummary[]>,
+    ssmTargets: Promise<TargetSummary[]>,
+    sshTargets: Promise<TargetSummary[]>,
+    envs: Promise<EnvironmentDetails[]>): Promise<parsedTargetString> {
+    let parsedTarget = parseTargetString(argvTargetType, argvTargetString);
+
+    if (!parsedTarget) {
+        logger.error('Invalid target string, must follow syntax:');
+        logger.error(targetStringExampleNoPath);
+        await cleanExit(1, logger);
+    }
+
+    if (!checkTargetTypeAndStringPair(parsedTarget)) {
+
+        switch (parsedTarget.type) {
+        case TargetType.SSH:
+            logger.warn('Cannot specify targetUser for SSH connections');
+            logger.warn('Please try your previous command without the targetUser');
+            logger.warn('Target string for SSH: targetId[:path]');
+            break;
+        case TargetType.SSM:
+        case TargetType.DYNAMIC:
+            logger.warn('Must specify targetUser for SSM and DYNAMIC connections');
+            logger.warn('Target string for SSM: targetUser@targetId[:path]');
+            break;
+        default:
+            throw new Error('Unhandled TargetType');
+        }
+        await cleanExit(1, logger);
+    }
+
+
+    if (parsedTarget.name) {
+        let matchedNamedTargets: TargetSummary[] = [];
+
+        switch (parsedTarget.type) {
+        case TargetType.SSM:
+            matchedNamedTargets = (await ssmTargets).filter(ssm => ssm.name === parsedTarget.name);
+            break;
+        case TargetType.SSH:
+            matchedNamedTargets = (await sshTargets).filter(ssh => ssh.name === parsedTarget.name);
+            break;
+        case TargetType.DYNAMIC:
+            matchedNamedTargets = (await dynamicConfigs).filter(config => config.name === parsedTarget.name);
+            break;
+        default:
+            logger.error(`Invalid TargetType passed ${parsedTarget.type}`);
+            await cleanExit(1, logger);
+        }
+
+        if (matchedNamedTargets.length < 1) {
+            logger.error(`No ${parsedTarget.type} targets found with name ${parsedTarget.name}`);
+            logger.warn('Target names are case sensitive');
+            logger.warn('To see list of all targets run: \'zli lt\'');
+            await cleanExit(1, logger);
+        } else if (matchedNamedTargets.length == 1) {
+            // the rest of the flow will work as before since the targetId has now been disambiguated
+            parsedTarget.id = matchedNamedTargets.pop().id;
+        } else {
+            // ambiguous target id, warn user, exit process
+            logger.warn(`Multiple ${parsedTarget.type} targets found with name ${parsedTarget.name}`);
+            const tableString = getTableOfTargets(matchedNamedTargets, await envs);
+            console.log(tableString);
+            logger.info('Please connect using \'target id\' instead of target name');
+            await cleanExit(1, logger);
+        }
+    }
+
+    return parsedTarget;
+}

--- a/src/handlers/copy.handler.ts
+++ b/src/handlers/copy.handler.ts
@@ -1,0 +1,44 @@
+import {
+    parseTargetString,
+    targetStringExample
+} from '../utils';
+import { FileService } from '../http.service/http.service';
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+import { cleanExit } from './clean-exit.handler';
+
+import fs from 'fs';
+
+
+export async function copyHandler(configService: ConfigService, logger: Logger, argv: any) {
+    const fileService = new FileService(configService, logger);
+
+    const sourceParsedString = parseTargetString(argv.targetType, argv.source);
+    const destParsedString = parseTargetString(argv.targetType, argv.destination);
+    const parsedTarget = sourceParsedString || destParsedString; // one of these will be undefined so javascript will use the other
+
+    // figure out upload or download
+    // would be undefined if not parsed properly
+    if(destParsedString)
+    {
+        // Upload case
+        // First ensure that the file exists
+        if (!fs.existsSync(argv.source)) {
+            logger.warn(`File ${argv.source} does not exist!`);
+            process.exit(1);
+        }
+
+        // Then create our read stream and try to upload it
+        const fh = fs.createReadStream(argv.source);
+        await fileService.uploadFile(parsedTarget.id, parsedTarget.type, parsedTarget.path, fh, parsedTarget.user);
+        logger.info('File upload complete');
+
+    } else if(sourceParsedString) {
+    // download case
+        await fileService.downloadFile(parsedTarget.id, parsedTarget.type, parsedTarget.path, argv.destination, parsedTarget.user);
+    } else {
+        logger.error('Invalid target string, must follow syntax:');
+        logger.error(targetStringExample);
+    }
+    await cleanExit(0, logger);
+}

--- a/src/handlers/list-targets.handler.ts
+++ b/src/handlers/list-targets.handler.ts
@@ -1,0 +1,49 @@
+import {
+    TargetSummary,
+    findSubstring,
+    parseTargetType,
+    getTableOfTargets
+} from '../utils';
+import { Logger } from '../logger.service/logger';
+import { EnvironmentDetails } from '../http.service/http.service.types';
+import { cleanExit } from './clean-exit.handler';
+
+
+export async function listTargetsHandler(
+    logger: Logger,
+    argv: any,
+    dynamicConfigs: Promise<TargetSummary[]>,
+    ssmTargets: Promise<TargetSummary[]>,
+    sshTargets: Promise<TargetSummary[]>,
+    envsPassed: Promise<EnvironmentDetails[]>) {
+    // await and concatenate
+    let allTargets = [...await ssmTargets, ...await sshTargets, ...await dynamicConfigs];
+    let envs = await envsPassed;
+
+    // find all envIds with substring search
+    // filter targets down by endIds
+    // ref for '!!': https://stackoverflow.com/a/29312197/14782428
+    if(!! argv.env)
+    {
+        const envIdFilter = envs.filter(e => findSubstring(argv.env, e.name)).map(e => e.id);
+
+        allTargets = allTargets.filter(t => envIdFilter.includes(t.environmentId));
+    }
+
+    // filter targets by name/alias
+    if(!! argv.name)
+    {
+        allTargets = allTargets.filter(t => findSubstring(argv.name, t.name));
+    }
+
+    // filter targets by TargetType
+    if(!! argv.targetType)
+    {
+        let targetType = parseTargetType(argv.targetType);
+        allTargets = allTargets.filter(t => t.type === targetType);
+    }
+
+    let tableString = getTableOfTargets(allTargets, envs);
+    console.log(tableString);
+    await cleanExit(0, logger);
+}

--- a/src/handlers/login.handler.ts
+++ b/src/handlers/login.handler.ts
@@ -1,0 +1,82 @@
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+import { OAuthService } from '../oauth.service/oauth.service';
+import { IdP } from '../types';
+import { MfaService, UserService } from '../http.service/http.service';
+import { MfaActionRequired } from '../http.service/http.service.types';
+import { cleanExit } from './clean-exit.handler';
+import { KeySplittingService } from '../../webshell-common-ts/keysplitting.service/keysplitting.service';
+
+import qrcode from 'qrcode';
+
+
+export async function loginHandler(configService: ConfigService, logger: Logger, argv: any, keySplittingService: KeySplittingService) {
+    // Clear previous log in info
+    configService.logout();
+    await keySplittingService.generateKeysplittingLoginData();
+
+    const provider = <IdP> argv.provider;
+    await configService.loginSetup(provider);
+
+    // Can only create oauth service after loginSetup completes
+    const oAuthService = new OAuthService(configService, logger);
+    if(! oAuthService.isAuthenticated())
+    {
+        logger.info('Login required, opening browser');
+
+        // Create our Nonce
+        const nonce = keySplittingService.createNonce();
+
+        // Pass it in as we login
+        await oAuthService.login((t) => {
+            configService.setTokenSet(t);
+            keySplittingService.setInitialIdToken(configService.getAuth());
+        }, nonce);
+    }
+
+    // Register user log in and get User Session Id
+    const userService = new UserService(configService, logger);
+    const registerResponse = await userService.Register();
+    configService.setSessionId(registerResponse.userSessionId);
+
+    // Check if we must MFA and act upon it
+    const mfaService = new MfaService(configService, logger);
+    switch(registerResponse.mfaActionRequired)
+    {
+    case MfaActionRequired.NONE:
+        break;
+    case MfaActionRequired.TOTP:
+        if(! argv.mfa)
+        {
+            logger.warn('MFA token required for this account');
+            logger.info('Please try logging in again with \'--mfa <token\' flag');
+            configService.logout();
+            await cleanExit(1, logger);
+        }
+
+        await mfaService.SendTotp(argv.mfa);
+
+        break;
+    case MfaActionRequired.RESET:
+        logger.info('MFA reset detected, requesting new MFA token');
+        logger.info('Please scan the following QR code with your device (Google Authenticator recommended)');
+
+        const resp = await mfaService.ResetSecret();
+        var data = await qrcode.toString(resp.mfaSecretUrl, {type: 'terminal', scale: 2});
+        console.log(data);
+
+        logger.info('Please log in again with \'--mfa token\'');
+
+        break;
+    default:
+        logger.warn(`Unexpected MFA response ${registerResponse.mfaActionRequired}`);
+        break;
+    }
+
+    const me = await userService.Me();
+    configService.setMe(me);
+
+    logger.info(`Logged in as: ${me.email}, bzero-id:${me.id}, session-id:${registerResponse.userSessionId}`);
+
+    await cleanExit(0, logger);
+}

--- a/src/handlers/logout.handler.ts
+++ b/src/handlers/logout.handler.ts
@@ -1,0 +1,12 @@
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+import { cleanExit } from './clean-exit.handler';
+
+
+export async function logoutHandler(configService: ConfigService, logger: Logger) {
+    // Deletes the auth tokens from the config which will force the
+    // user to login again before running another command
+    configService.logout();
+    logger.info('Logout successful');
+    await cleanExit(0, logger);
+}

--- a/src/handlers/middleware.handler.ts
+++ b/src/handlers/middleware.handler.ts
@@ -1,0 +1,102 @@
+import { Logger } from '../logger.service/logger';
+import { ConfigService } from '../config.service/config.service';
+import {
+    DynamicAccessConfigService,
+    EnvironmentService,
+    SshTargetService,
+    SsmTargetService
+} from '../http.service/http.service';
+import { TargetSummary } from '../utils';
+import { TargetType } from '../types';
+import { MixpanelService } from '../mixpanel.service/mixpanel.service';
+import { version } from '../../package.json';
+import { oauthMiddleware } from '../middlewares/oauth-middleware';
+import { LoggerConfigService } from '../logger-config.service/logger-config.service';
+import { KeySplittingService } from '../../webshell-common-ts/keysplitting.service/keysplitting.service';
+
+
+export function fetchDataMiddleware(configService: ConfigService, logger: Logger) {
+    // Greedy fetch of some data that we use frequently
+    const ssmTargetService = new SsmTargetService(configService, logger);
+    const sshTargetService = new SshTargetService(configService, logger);
+    const dynamicConfigService = new DynamicAccessConfigService(configService, logger);
+    const envService = new EnvironmentService(configService, logger);
+
+    var dynamicConfigs = dynamicConfigService.ListDynamicAccessConfigs()
+        .then(result =>
+            result.map<TargetSummary>((config, _index, _array) => {
+                return {type: TargetType.DYNAMIC, id: config.id, name: config.name, environmentId: config.environmentId};
+            })
+        );
+
+    var ssmTargets = ssmTargetService.ListSsmTargets(false)
+        .then(result =>
+            result.map<TargetSummary>((ssm, _index, _array) => {
+                return {type: TargetType.SSM, id: ssm.id, name: ssm.name, environmentId: ssm.environmentId};
+            })
+        );
+
+
+    var sshTargets = sshTargetService.ListSshTargets()
+        .then(result =>
+            result.map<TargetSummary>((ssh, _index, _array) => {
+                return {type: TargetType.SSH, id: ssh.id, name: ssh.alias, environmentId: ssh.environmentId};
+            })
+        );
+
+    var envs = envService.ListEnvironments();
+
+    return {
+        dynamicConfigs: dynamicConfigs,
+        ssmTargets: ssmTargets,
+        sshTargets: sshTargets,
+        envs: envs
+    };
+}
+
+export function mixedPanelTrackingMiddleware(configService: ConfigService, argv: any) {
+    // Mixpanel tracking
+    var mixedPanelService = new MixpanelService(configService);
+
+    // Only captures args, not options at the moment. Capturing configName flag
+    // does not matter as that is handled by which mixpanel token is used
+    // TODO: capture options and flags
+    mixedPanelService.TrackCliCall(
+        'CliCommand',
+        {
+            'cli-version': version,
+            'command': argv._[0],
+            args: argv._.slice(1)
+        }
+    );
+
+    return mixedPanelService;
+}
+
+export function oAuthMiddleware(configService: ConfigService, logger: Logger) {
+    // OAuth
+    oauthMiddleware(configService, logger);
+    const me = configService.me(); // if you have logged in, this should be set
+    const sessionId = configService.sessionId();
+    logger.info(`Logged in as: ${me.email}, bzero-id:${me.id}, session-id:${sessionId}`);
+}
+
+export async function initMiddleware(argv: any) {
+    // Configure our logger
+    var loggerConfigService = new LoggerConfigService(<string> argv.configName);
+    var logger = new Logger(loggerConfigService, !!argv.debug, !!argv.silent);
+
+    // Config init
+    var configService = new ConfigService(<string>argv.configName, logger);
+
+    // KeySplittingService init
+    var keySplittingService = new KeySplittingService(configService, logger);
+    await keySplittingService.init();
+
+    return {
+        loggingConfigService: loggerConfigService,
+        logger: logger,
+        configService: configService,
+        keySplittingService: keySplittingService
+    };
+}

--- a/src/handlers/ssh-proxy-config.handler.ts
+++ b/src/handlers/ssh-proxy-config.handler.ts
@@ -1,0 +1,25 @@
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+
+
+export function sshProxyConfigHandler(configService: ConfigService, logger: Logger, processName: string) {
+    let keyPath = configService.sshKeyPath();
+    let configName = configService.getConfigName();
+    let configNameArg = '';
+    if(configName != 'prod') {
+        configNameArg = `--configName=${configName}`;
+    }
+
+    logger.info(`
+Add the following lines to your ssh config (~/.ssh/config) file:
+
+host bzero-*
+IdentityFile ${keyPath}
+ProxyCommand ${processName} ssh-proxy ${configNameArg} -s %h %r %p ${keyPath}
+
+
+Then you can use native ssh to connect to any of your ssm targets using the following syntax:
+
+ssh <user>@bzero-<ssm-target-id-or-name>
+`);
+}

--- a/src/handlers/ssh-proxy.handler.ts
+++ b/src/handlers/ssh-proxy.handler.ts
@@ -1,0 +1,21 @@
+import { KeySplittingService } from '../../webshell-common-ts/keysplitting.service/keysplitting.service';
+import { ConfigService } from '../config.service/config.service';
+import { Logger } from '../logger.service/logger';
+import { SsmTunnelService } from '../ssm-tunnel/ssm-tunnel.service';
+import { cleanExit } from './clean-exit.handler';
+import { Dictionary } from 'lodash';
+
+
+export async function sshProxyHandler(configService: ConfigService, logger: Logger, argv: any, keySplittingService: KeySplittingService, envMap: Dictionary<string>) {
+    let ssmTunnelService = new SsmTunnelService(logger, configService, keySplittingService, envMap['enableKeysplitting'] == 'true');
+    ssmTunnelService.errors.subscribe(async errorMessage => {
+        process.stderr.write(`\n${errorMessage}\n`);
+        await cleanExit(1, logger);
+    });
+
+    if( await ssmTunnelService.setupWebsocketTunnel(argv.host, argv.user, argv.port, argv.identityFile)) {
+        process.stdin.on('data', async (data) => {
+            ssmTunnelService.sendData(data);
+        });
+    }
+}


### PR DESCRIPTION
Relates to JIRA: CWC-518
Relates to #13 

This pr extracts the code from `cli-driver` into handler functions and a handler folder. Please see the github issue for more detail on what we decided, but the modivation for this is to avoid having a huge file for `cli-driver` and split up the code across different handler functions. 