### PR TITLE
Add option for -detail flag for list-targets

### DIFF
--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -199,6 +199,14 @@ export class CliDriver
                                 demandOption: false,
                                 alias: 'n'
                             }
+                        )
+                        .option(
+                            'detail',
+                            {
+                                type: 'boolean',
+                                default: false,
+                                alias: 'd'
+                            }
                         );
                 },
                 async (argv) => {

--- a/src/handlers/list-targets.handler.ts
+++ b/src/handlers/list-targets.handler.ts
@@ -43,7 +43,7 @@ export async function listTargetsHandler(
         allTargets = allTargets.filter(t => t.type === targetType);
     }
 
-    const tableString = getTableOfTargets(allTargets, envs);
+    const tableString = getTableOfTargets(allTargets, envs, !! argv.detail);
     console.log(tableString);
     await cleanExit(0, logger);
 }

--- a/src/handlers/middleware.handler.ts
+++ b/src/handlers/middleware.handler.ts
@@ -25,7 +25,7 @@ export function fetchDataMiddleware(configService: ConfigService, logger: Logger
     const dynamicConfigs = dynamicConfigService.ListDynamicAccessConfigs()
         .then(result =>
             result.map<TargetSummary>((config, _index, _array) => {
-                return {type: TargetType.DYNAMIC, id: config.id, name: config.name, environmentId: config.environmentId};
+                return {type: TargetType.DYNAMIC, id: config.id, name: config.name, environmentId: config.environmentId, status: 'N/A', agentVersion: 'N/A'};
             })
         );
 
@@ -35,7 +35,7 @@ export function fetchDataMiddleware(configService: ConfigService, logger: Logger
     const ssmTargets = ssmTargetService.ListSsmTargets(true)
         .then(result =>
             result.map<TargetSummary>((ssm, _index, _array) => {
-                return {type: TargetType.SSM, id: ssm.id, name: ssm.name, environmentId: ssm.environmentId};
+                return {type: TargetType.SSM, id: ssm.id, name: ssm.name, environmentId: ssm.environmentId, status: ssm.status, agentVersion: ssm.agentVersion ? ssm.agentVersion : 'N/A'};
             })
         );
 
@@ -43,7 +43,7 @@ export function fetchDataMiddleware(configService: ConfigService, logger: Logger
     const sshTargets = sshTargetService.ListSshTargets()
         .then(result =>
             result.map<TargetSummary>((ssh, _index, _array) => {
-                return {type: TargetType.SSH, id: ssh.id, name: ssh.alias, environmentId: ssh.environmentId};
+                return {type: TargetType.SSH, id: ssh.id, name: ssh.alias, environmentId: ssh.environmentId, status: 'N/A', agentVersion: 'N/A'};
             })
         );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,20 +92,33 @@ export interface TargetSummary
     name: string;
     environmentId: string;
     type: TargetType;
+    status: string;
+    agentVersion: string;
 }
 
-export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[]) : string
+export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[], detail: boolean = false) : string
 {
     const targetNameLength = max(targets.map(t => t.name.length).concat(16)); // if max is 0 then use 16 as width
     const envNameLength = max(envs.map(e => e.name.length).concat(16));       // same same
+    const statusNameLength = max(targets.map(t => t.status.length).concat(16));
+    const agentVersionNameLength = max(targets.map(t => t.agentVersion.length).concat(16));
 
     // ref: https://github.com/cli-table/cli-table3
-    const table = new Table({
-        head: ['Type', 'Name', 'Environment', 'Id']
-        , colWidths: [10, targetNameLength + 2, envNameLength + 2, 38]
-    });
-
-    targets.forEach(target => table.push([target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name, target.id]));
+    let table = undefined;
+    if (detail == true) {
+        table = new Table({
+            head: ['Type', 'Name', 'Status', 'Environment', 'Id', 'Agent Version']
+            , colWidths: [10, targetNameLength + 2,  statusNameLength + 2, envNameLength + 2, 38, agentVersionNameLength + 2]
+        });
+        targets.forEach(target => table.push([target.type, target.name, target.status, envs.filter(e => e.id == target.environmentId).pop().name, target.id, target.agentVersion]));
+    }
+    else {
+        table = new Table({
+            head: ['Type', 'Name', 'Environment', 'Id']
+            , colWidths: [10, targetNameLength + 2, envNameLength + 2, 38]
+        });
+        targets.forEach(target => table.push([target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name, target.id]));
+    }
 
     return table.toString();
 }


### PR DESCRIPTION
Closes #75 
Relates to JIRA: CWC-570

This PR adds the ability to pass a `--detail/-d` flag to `list-targets` so we can see more info about the targets (in this case Status and Agent Version). 

~The `--wide` was taken from the `kubectl get pods -o wide` cli: https://kubernetes.io/docs/reference/kubectl/cheatsheet/~