### PR TITLE
SSH style syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,8 +65,8 @@
         "typescript": "^4.0.5"
       },
       "engines": {
-        "node": ">=0.12 <0.13",
-        "npm": ">=7.0.0"
+        "node": ">0.12.0",
+        "npm": ">7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
-      "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+      "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1523,6 +1523,58 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1869,6 +1921,17 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2096,6 +2159,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -2229,6 +2298,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -2360,6 +2438,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "node_modules/contains-path": {
       "version": "0.1.0",
@@ -2556,6 +2640,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2648,6 +2741,24 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-newline": {
@@ -3913,6 +4024,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -3957,6 +4074,69 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -4023,6 +4203,12 @@
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
     },
     "node_modules/glob": {
       "version": "7.1.6",
@@ -4172,6 +4358,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -4457,6 +4649,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/into-stream": {
       "version": "5.1.1",
@@ -6276,6 +6474,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6349,6 +6553,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6365,6 +6575,24 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/noble-ed25519/-/noble-ed25519-1.0.4.tgz",
       "integrity": "sha512-Sp9F8ukrY5v9PZezW8Q8dI+tbIH5f6i4E2Alb7kPDPgsQA5CgsrM0BVyUoy06/CRH5QoN2QUOVZH+QIXgesNLQ=="
+    },
+    "node_modules/node-abi": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+      "integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -6444,6 +6672,12 @@
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
+    "node_modules/noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6501,6 +6735,27 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nwsapi": {
@@ -6929,13 +7184,13 @@
       }
     },
     "node_modules/pkg": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.4.9.tgz",
-      "integrity": "sha512-FK4GqHtcCY2PPPVaKViU0NyRzpo6gCS7tPKN5b7AkElqjAOCH1bsRKgohEnxThr6DWfTGByGqba2YHGR/BqbmA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.5.1.tgz",
+      "integrity": "sha512-UXKL88jGQ+FD4//PyrFeRcqurVQ3BVIfUNaEU9cXY24EJz08JyBj85qrGh0CFGvyzNb1jpwHOnns5Sw0M5H92Q==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.9.4",
-        "@babel/runtime": "^7.9.2",
+        "@babel/parser": "7.13.12",
+        "@babel/runtime": "7.13.10",
         "chalk": "^3.0.0",
         "escodegen": "^1.14.1",
         "fs-extra": "^8.1.0",
@@ -6943,13 +7198,22 @@
         "into-stream": "^5.1.1",
         "minimist": "^1.2.5",
         "multistream": "^2.1.1",
-        "pkg-fetch": "^2.6.9",
+        "pkg-fetch": "2.6.9",
+        "prebuild-install": "6.0.1",
         "progress": "^2.0.3",
         "resolve": "^1.15.1",
         "stream-meter": "^1.0.4"
       },
       "bin": {
         "pkg": "lib-es5/bin.js"
+      },
+      "peerDependencies": {
+        "node-notifier": ">=6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
       }
     },
     "node_modules/pkg-dir": {
@@ -7178,6 +7442,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7359,6 +7652,30 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -8059,6 +8376,61 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-get/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-get/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -8633,6 +9005,34 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/term-size": {
       "version": "2.2.1",
@@ -9334,6 +9734,64 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
+    "node_modules/which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/wide-align/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wide-align/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/winston": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
@@ -9916,9 +10374,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
-      "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
+      "integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -10906,6 +11364,60 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -11185,6 +11697,17 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -11373,6 +11896,12 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -11480,6 +12009,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -11600,6 +12135,12 @@
         "pkg-up": "^3.1.0",
         "semver": "^7.3.2"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -11762,6 +12303,12 @@
         }
       }
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -11833,6 +12380,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -12877,6 +13436,12 @@
         }
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -12912,6 +13477,59 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -12963,6 +13581,12 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -13081,6 +13705,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -13306,6 +13936,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "into-stream": {
       "version": "5.1.1",
@@ -14765,6 +15401,12 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -14837,6 +15479,12 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -14853,6 +15501,23 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/noble-ed25519/-/noble-ed25519-1.0.4.tgz",
       "integrity": "sha512-Sp9F8ukrY5v9PZezW8Q8dI+tbIH5f6i4E2Alb7kPDPgsQA5CgsrM0BVyUoy06/CRH5QoN2QUOVZH+QIXgesNLQ=="
+    },
+    "node-abi": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+      "integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -14928,6 +15593,12 @@
         }
       }
     },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -14975,6 +15646,24 @@
           "dev": true
         }
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -15301,13 +15990,13 @@
       }
     },
     "pkg": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.4.9.tgz",
-      "integrity": "sha512-FK4GqHtcCY2PPPVaKViU0NyRzpo6gCS7tPKN5b7AkElqjAOCH1bsRKgohEnxThr6DWfTGByGqba2YHGR/BqbmA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.5.1.tgz",
+      "integrity": "sha512-UXKL88jGQ+FD4//PyrFeRcqurVQ3BVIfUNaEU9cXY24EJz08JyBj85qrGh0CFGvyzNb1jpwHOnns5Sw0M5H92Q==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.9.4",
-        "@babel/runtime": "^7.9.2",
+        "@babel/parser": "7.13.12",
+        "@babel/runtime": "7.13.10",
         "chalk": "^3.0.0",
         "escodegen": "^1.14.1",
         "fs-extra": "^8.1.0",
@@ -15315,7 +16004,8 @@
         "into-stream": "^5.1.1",
         "minimist": "^1.2.5",
         "multistream": "^2.1.1",
-        "pkg-fetch": "^2.6.9",
+        "pkg-fetch": "2.6.9",
+        "prebuild-install": "6.0.1",
         "progress": "^2.0.3",
         "resolve": "^1.15.1",
         "stream-meter": "^1.0.4"
@@ -15495,6 +16185,29 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prebuild-install": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15640,6 +16353,26 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
     },
     "react-is": {
       "version": "17.0.1",
@@ -16220,6 +16953,40 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+          "dev": true
+        }
+      }
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -16706,6 +17473,31 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       }
     },
     "term-size": {
@@ -17288,6 +18080,54 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "winston": {
       "version": "3.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "zli",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.12.0",
+      "name": "zli",
+      "version": "4.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/signalr": "^5.0.0",
@@ -65,7 +66,7 @@
       },
       "engines": {
         "node": ">=0.12 <0.13",
-        "npm": ">=6.0.0"
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "zli",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "bin": "dist/src/index.js",
   "engines": {
     "node": ">=0.12 <0.13",
-    "npm": ">=6.0.0"
+    "npm": ">=7.0.0"
   },
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
   "pkg": {
     "scripts": [],
     "assets": [
-      "node_modules/figlet/fonts/Standard.flf",
-      "src/oauth.service/templates/*.html"
+      "node_modules/figlet/fonts/Standard.flf"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "dist/src/index.d.ts",
   "bin": "dist/src/index.js",
   "engines": {
-    "node": ">=0.12 <0.13",
-    "npm": ">=7.0.0"
+    "node": ">0.12.0",
+    "npm": ">7.0.0"
   },
   "scripts": {
     "start": "ts-node src/index.ts",
@@ -77,7 +77,8 @@
   "pkg": {
     "scripts": [],
     "assets": [
-      "node_modules/figlet/fonts/Standard.flf"
+      "node_modules/figlet/fonts/Standard.flf",
+      "src/oauth.service/templates/*.html"
     ]
   }
 }

--- a/src/__test__/utils.test.ts
+++ b/src/__test__/utils.test.ts
@@ -1,5 +1,5 @@
-import { TargetType } from '../types';
-import { checkTargetTypeAndStringPair, parsedTargetString, parseTargetString, parseTargetType } from '../utils';
+import { ParsedTargetString, TargetType } from '../types';
+import { checkTargetTypeAndStringPair, parseTargetString, parseTargetType } from '../utils';
 
 test('valid targetType strings', () => {
     const validSSMTargetTypeStrings = [
@@ -35,7 +35,7 @@ test('valid targetStrings', () => {
         'ssm-user@97d4d916-33f8-478e-9e6c-1091662ccaf0:asdfjl; asdfla;sd',
         '97d4d916-33f8-478e-9e6c-1091662ccaf0:asdfjl; asdfla;sd'
     ];
-    validSSMTargetStrings.forEach(t => expect(parseTargetString('ssm',t)).toBeDefined());
+    validSSMTargetStrings.forEach(t => expect(parseTargetString(t)).toBeDefined());
 });
 
 test('invalid targetStrings', () => {
@@ -45,23 +45,23 @@ test('invalid targetStrings', () => {
         'ssm-user@:97d4d916-33f8-478e-9e6c-1091662ccaf0', // colon wrong place
         'ss!!!r@whatsUp!Word:/cool' // invalid character in target name
     ];
-    validSSMTargetStrings.forEach(t => expect(parseTargetString('ssh',t)).toBeUndefined());
+    validSSMTargetStrings.forEach(t => expect(parseTargetString(t)).toBeUndefined());
 });
 
 test('properly matched targetType and targetStrings', () => {
 
-    const correctSsmParsedTarget: parsedTargetString[] =[
-        { id: '123123', user: 'ssm-user', type: TargetType.SSM, name: 'hello-world', path: '/var/log' },
-        { id: '123123', user: 'ssm-user', type: TargetType.SSM, name: 'hello-world', path: undefined },
-        { id: '123123', user: 'ssm-user', type: TargetType.SSM, name: undefined, path: undefined }
+    const correctSsmParsedTarget: ParsedTargetString[] = [
+        { id: '123123', user: 'ssm-user', type: TargetType.SSM, name: 'hello-world', path: '/var/log', envId: undefined, envName: undefined },
+        { id: '123123', user: 'ssm-user', type: TargetType.SSM, name: 'hello-world', path: undefined, envId: undefined, envName: undefined },
+        { id: '123123', user: 'ssm-user', type: TargetType.SSM, name: undefined, path: undefined, envId: undefined, envName: undefined }
     ];
 
     correctSsmParsedTarget.forEach(t => expect(checkTargetTypeAndStringPair(t)).toBeTruthy());
 
-    const correctSshParsedTarget: parsedTargetString[] =[
-        { id: '123123', user: undefined, type: TargetType.SSH, name: 'hello-world', path: '/var/log' },
-        { id: '123123', user: undefined, type: TargetType.SSH, name: 'hello-world', path: undefined },
-        { id: '123123', user: undefined, type: TargetType.SSH, name: undefined, path: undefined }
+    const correctSshParsedTarget: ParsedTargetString[] = [
+        { id: '123123', user: undefined, type: TargetType.SSH, name: 'hello-world', path: '/var/log', envId: undefined, envName: undefined },
+        { id: '123123', user: undefined, type: TargetType.SSH, name: 'hello-world', path: undefined, envId: undefined, envName: undefined },
+        { id: '123123', user: undefined, type: TargetType.SSH, name: undefined, path: undefined, envId: undefined, envName: undefined }
     ];
 
     correctSshParsedTarget.forEach(t => expect(checkTargetTypeAndStringPair(t)).toBeTruthy());
@@ -69,18 +69,18 @@ test('properly matched targetType and targetStrings', () => {
 
 test('improperly matched targetType and targetStrings', () => {
 
-    const correctSsmParsedTarget: parsedTargetString[] =[
-        { id: '123123', user: undefined, type: TargetType.SSM, name: 'hello-world', path: '/var/log' },
-        { id: '123123', user: undefined, type: TargetType.SSM, name: 'hello-world', path: undefined },
-        { id: '123123', user: undefined, type: TargetType.SSM, name: undefined, path: undefined }
+    const correctSsmParsedTarget: ParsedTargetString[] = [
+        { id: '123123', user: undefined, type: TargetType.SSM, name: 'hello-world', path: '/var/log', envId: undefined, envName: undefined },
+        { id: '123123', user: undefined, type: TargetType.SSM, name: 'hello-world', path: undefined, envId: undefined, envName: undefined },
+        { id: '123123', user: undefined, type: TargetType.SSM, name: undefined, path: undefined, envId: undefined, envName: undefined }
     ];
 
     correctSsmParsedTarget.forEach(t => expect(checkTargetTypeAndStringPair(t)).toBeFalsy());
 
-    const correctSshParsedTarget: parsedTargetString[] =[
-        { id: '123123', user: 'ssm-user', type: TargetType.SSH, name: 'hello-world', path: '/var/log' },
-        { id: '123123', user: 'ssm-user', type: TargetType.SSH, name: 'hello-world', path: undefined },
-        { id: '123123', user: 'ssm-user', type: TargetType.SSH, name: undefined, path: undefined }
+    const correctSshParsedTarget: ParsedTargetString[] = [
+        { id: '123123', user: 'ssm-user', type: TargetType.SSH, name: 'hello-world', path: '/var/log', envId: undefined, envName: undefined },
+        { id: '123123', user: 'ssm-user', type: TargetType.SSH, name: 'hello-world', path: undefined, envId: undefined, envName: undefined },
+        { id: '123123', user: 'ssm-user', type: TargetType.SSH, name: undefined, path: undefined, envId: undefined, envName: undefined }
     ];
 
     correctSshParsedTarget.forEach(t => expect(checkTargetTypeAndStringPair(t)).toBeFalsy());

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -112,7 +112,8 @@ export class CliDriver
                                 alias: 'm'
                             }
                         )
-                        .example('login Google', 'Login with Google');
+                        .example('login Google', 'Login with Google')
+                        .example('login Google --mfa 123456', 'Login with Microsoft and enter MFA');
                 },
                 async (argv) => {
                     await loginHandler(this.configService, this.logger, argv, this.keySplittingService);
@@ -135,8 +136,8 @@ export class CliDriver
                                 alias: 't'
                             },
                         )
-                        .example('connect ssm-user@neat-name', 'SSM connect example')
-                        .example('connect dbda775d-e37c-402b-aa76-bbb0799fd775', 'SSH connect example');
+                        .example('connect ssm-user@neat-target', 'SSM connect example, uniquely named ssm target')
+                        .example('connect dbda775d-e37c-402b-aa76-bbb0799fd775', 'SSH connect example, unique id of ssh target');
                 },
                 async (argv) => {
                     const parsedTarget = await disambiguateTarget(argv.targetType, argv.targetString, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
@@ -173,7 +174,8 @@ export class CliDriver
                                 demandOption: false,
                                 alias: 'n'
                             }
-                        ).option(
+                        )
+                        .option(
                             'showId',
                             {
                                 type: 'boolean',
@@ -181,7 +183,8 @@ export class CliDriver
                                 demandOption: false,
                                 alias: 'i'
                             }
-                        ).option(
+                        )
+                        .option(
                             'json',
                             {
                                 type: 'boolean',
@@ -189,7 +192,10 @@ export class CliDriver
                                 demandOption: false,
                                 alias: 'j',
                             }
-                        );
+                        )
+                        .example('lt -t ssm', 'List all SSM targets only')
+                        .example('lt -i', 'List all targets and show unique ids')
+                        .example('lt -e prod --json --silent', 'List all targets targets in prod, output as json, pipeable');
                 },
                 async (argv) => {
                     await listTargetsHandler(this.logger, argv, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
@@ -219,8 +225,8 @@ export class CliDriver
                                 alias: 't'
                             }
                         )
-                        .example('copy ssm-user@95b72b50-d09c-49fa-8825-332abfeb013e:/home/ssm-user/file.txt /Users/coolUser/newFileName.txt', 'Download example')
-                        .example('copy /Users/coolUser/secretFile.txt ssm-user@neat-target:/home/ssm-user/newFileName', 'Upload example');
+                        .example('copy ssm-user@neat-target:/home/ssm-user/file.txt /Users/coolUser/newFileName.txt', 'Download example, relative to your machine')
+                        .example('copy /Users/coolUser/secretFile ssm-user@neat-target:/home/ssm-user/newFileName', 'Upload example, relative to your machine');
                 },
                 async (argv) => {
                     const sourceParsedTarget = await disambiguateTarget(argv.targetType, argv.source, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
@@ -320,8 +326,8 @@ export class CliDriver
             .help() // auto gen help message
             .epilog(`Note:
  - <targetString> format: ${targetStringExample}
- - TargetStrings only require targetUser for SSM
- - TargetPath can be omitted
+ - TargetStrings only require targetUser for SSM and Dynamic targets
+ - TargetPath can be omitted for connect
 
 For command specific help: zli <cmd> help
 
@@ -329,7 +335,7 @@ Command arguments key:
  - <arg> is required
  - [arg] is optional or sometimes required
 
-Need help? https://app.bastionzero.com/support`)
+Need help? https://cloud.bastionzero.com/support`)
             .argv; // returns argv of yargs
     }
 }

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -199,6 +199,14 @@ export class CliDriver
                                 demandOption: false,
                                 alias: 'n'
                             }
+                        ).option(
+                            'showId',
+                            {
+                                type: 'boolean',
+                                default: false,
+                                demandOption: false,
+                                alias: 'i'
+                            }
                         );
                 },
                 async (argv) => {

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -279,7 +279,6 @@ export class CliDriver
                     }
 
                     if(! argv.host.startsWith(prefix)) {
-                        // TODO throw versus exit?
                         this.logger.error(`Invalid host provided must have form ${prefix}<target>. Target must be either target id or name`);
                         cleanExit(1, this.logger);
                     }

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -176,6 +176,15 @@ export class CliDriver
                             }
                         )
                         .option(
+                            'detail',
+                            {
+                                type: 'boolean',
+                                default: false,
+                                demandOption: false,
+                                alias: 'd'
+                            }
+                        )
+                        .option(
                             'showId',
                             {
                                 type: 'boolean',

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -181,6 +181,14 @@ export class CliDriver
                                 demandOption: false,
                                 alias: 'i'
                             }
+                        ).option(
+                            'json',
+                            {
+                                type: 'boolean',
+                                default: false,
+                                demandOption: false,
+                                alias: 'j',
+                            }
                         );
                 },
                 async (argv) => {
@@ -259,7 +267,7 @@ export class CliDriver
                 },
                 async (argv) => {
                     let prefix = 'bzero-';
-                    let configName = this.configService.getConfigName();
+                    const configName = this.configService.getConfigName();
                     if(configName != 'prod') {
                         prefix = `${configName}-${prefix}`;
                     }
@@ -269,7 +277,7 @@ export class CliDriver
                         this.logger.error(`Invalid host provided must have form ${prefix}<target>. Target must be either target id or name`);
                         cleanExit(1, this.logger);
                     }
-                    
+
                     // modify argv to have the targetString and targetType params
                     const targetString = argv.user + '@' + argv.host.substr(prefix.length);
                     const parsedTarget = await disambiguateTarget('ssm', targetString, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -139,7 +139,7 @@ export class CliDriver
                         .example('connect dbda775d-e37c-402b-aa76-bbb0799fd775', 'SSH connect example');
                 },
                 async (argv) => {
-                    const parsedTarget = await disambiguateTarget(argv, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
+                    const parsedTarget = await disambiguateTarget(argv.targetType, argv.targetString, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
 
                     await connectHandler(this.configService, this.logger, this.mixpanelService, parsedTarget);
                 }
@@ -215,8 +215,8 @@ export class CliDriver
                         .example('copy /Users/coolUser/secretFile.txt ssm-user@neat-target:/home/ssm-user/newFileName', 'Upload example');
                 },
                 async (argv) => {
-                    const sourceParsedTarget = await disambiguateTarget(argv.source, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
-                    const destParsedTarget = await disambiguateTarget(argv.destination, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
+                    const sourceParsedTarget = await disambiguateTarget(argv.targetType, argv.source, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
+                    const destParsedTarget = await disambiguateTarget(argv.targetType, argv.destination, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
 
                     if(! sourceParsedTarget && ! destParsedTarget)
                     {
@@ -271,9 +271,8 @@ export class CliDriver
                     }
                     
                     // modify argv to have the targetString and targetType params
-                    argv.targetString = argv.user + '@' + argv.host.substr(prefix.length);
-                    argv.targetType = 'ssm';
-                    const parsedTarget = await disambiguateTarget(argv, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
+                    const targetString = argv.user + '@' + argv.host.substr(prefix.length);
+                    const parsedTarget = await disambiguateTarget('ssm', targetString, this.logger, this.dynamicConfigs, this.ssmTargets, this.sshTargets, this.envs);
 
                     if(argv.port < 1 || argv.port > 65535)
                     {

--- a/src/handlers/connect.handler.ts
+++ b/src/handlers/connect.handler.ts
@@ -1,33 +1,27 @@
 import { ConfigService } from '../config.service/config.service';
 import { Logger } from '../logger.service/logger';
 import { SessionService, ConnectionService } from '../http.service/http.service';
-import { EnvironmentDetails, ConnectionState } from '../http.service/http.service.types';
-import { SessionState, TargetType } from '../types';
-import {
-    TargetSummary,
-    parsedTargetString,
-    parseTargetString,
-    checkTargetTypeAndStringPair,
-    getTableOfTargets,
-    targetStringExampleNoPath
-} from '../utils';
+import { ConnectionState } from '../http.service/http.service.types';
+import { ParsedTargetString, SessionState, TargetType } from '../types';
 import { ShellTerminal } from '../terminal/terminal';
 import { MixpanelService } from '../mixpanel.service/mixpanel.service';
 import { cleanExit } from './clean-exit.handler';
 
 import termsize from 'term-size';
+import { targetStringExampleNoPath } from '../utils';
 
 
 export async function connectHandler(
     configService: ConfigService,
     logger: Logger,
-    argv: any,
     mixpanelService: MixpanelService,
-    dynamicConfigs: Promise<TargetSummary[]>,
-    ssmTargets: Promise<TargetSummary[]>,
-    sshTargets: Promise<TargetSummary[]>,
-    envs: Promise<EnvironmentDetails[]>) {
-    const parsedTarget = await disambiguateTargetName(argv.targetType, argv.targetString, logger, dynamicConfigs, ssmTargets, sshTargets, envs);
+    parsedTarget: ParsedTargetString) {
+    
+    if(! parsedTarget) {
+        logger.error('No targets matched your targetName/targetId or invalid target string, must follow syntax:');
+        logger.error(targetStringExampleNoPath);
+        await cleanExit(1, logger);
+    }
 
     // call list session
     const sessionService = new SessionService(configService, logger);
@@ -62,10 +56,7 @@ export async function connectHandler(
         logger.error('Connection creation failed');
         if(parsedTarget.type !== TargetType.SSH)
         {
-            const allSsmBasedTargets = (await ssmTargets).concat(await dynamicConfigs);
-            const targetEnvId = allSsmBasedTargets.filter(ssm => ssm.id == parsedTarget.id)[0].environmentId;
-            const targetEnvName = (await envs).filter(e => e.id == targetEnvId)[0].name;
-            logger.error(`You may not have a policy for targetUser ${parsedTarget.user} in environment ${targetEnvName}`);
+            logger.error(`You may not have a policy for targetUser ${parsedTarget.user} in environment ${parsedTarget.envName}`);
             logger.info('You can find SSM user policies in the web app');
         } else {
             logger.info('Please check your polices in the web app for this target and/or environment');
@@ -131,82 +122,4 @@ export async function connectHandler(
     readline.emitKeypressEvents(process.stdin);
     process.stdin.setRawMode(true);
     process.stdin.on('keypress', (_, key) => terminal.writeString(key.sequence));
-}
-
-
-// Figure out target id based on target name and target type.
-// Also preforms error checking on target type and target string passed in
-export async function disambiguateTargetName(
-    argvTargetType: string,
-    argvTargetString: string,
-    logger: Logger,
-    dynamicConfigs: Promise<TargetSummary[]>,
-    ssmTargets: Promise<TargetSummary[]>,
-    sshTargets: Promise<TargetSummary[]>,
-    envs: Promise<EnvironmentDetails[]>): Promise<parsedTargetString> {
-    const parsedTarget = parseTargetString(argvTargetType, argvTargetString);
-
-    if (!parsedTarget) {
-        logger.error('Invalid target string, must follow syntax:');
-        logger.error(targetStringExampleNoPath);
-        await cleanExit(1, logger);
-    }
-
-    if (!checkTargetTypeAndStringPair(parsedTarget)) {
-
-        switch (parsedTarget.type) {
-        case TargetType.SSH:
-            logger.warn('Cannot specify targetUser for SSH connections');
-            logger.warn('Please try your previous command without the targetUser');
-            logger.warn('Target string for SSH: targetId[:path]');
-            break;
-        case TargetType.SSM:
-        case TargetType.DYNAMIC:
-            logger.warn('Must specify targetUser for SSM and DYNAMIC connections');
-            logger.warn('Target string for SSM: targetUser@targetId[:path]');
-            break;
-        default:
-            throw new Error('Unhandled TargetType');
-        }
-        await cleanExit(1, logger);
-    }
-
-
-    if (parsedTarget.name) {
-        let matchedNamedTargets: TargetSummary[] = [];
-
-        switch (parsedTarget.type) {
-        case TargetType.SSM:
-            matchedNamedTargets = (await ssmTargets).filter(ssm => ssm.name === parsedTarget.name);
-            break;
-        case TargetType.SSH:
-            matchedNamedTargets = (await sshTargets).filter(ssh => ssh.name === parsedTarget.name);
-            break;
-        case TargetType.DYNAMIC:
-            matchedNamedTargets = (await dynamicConfigs).filter(config => config.name === parsedTarget.name);
-            break;
-        default:
-            logger.error(`Invalid TargetType passed ${parsedTarget.type}`);
-            await cleanExit(1, logger);
-        }
-
-        if (matchedNamedTargets.length < 1) {
-            logger.error(`No ${parsedTarget.type} targets found with name ${parsedTarget.name}`);
-            logger.warn('Target names are case sensitive');
-            logger.warn('To see list of all targets run: \'zli lt\'');
-            await cleanExit(1, logger);
-        } else if (matchedNamedTargets.length == 1) {
-            // the rest of the flow will work as before since the targetId has now been disambiguated
-            parsedTarget.id = matchedNamedTargets.pop().id;
-        } else {
-            // ambiguous target id, warn user, exit process
-            logger.warn(`Multiple ${parsedTarget.type} targets found with name ${parsedTarget.name}`);
-            const tableString = getTableOfTargets(matchedNamedTargets, await envs, true);
-            console.log(tableString);
-            logger.info('Please connect using the target\'s id instead of target name');
-            await cleanExit(1, logger);
-        }
-    }
-
-    return parsedTarget;
 }

--- a/src/handlers/connect.handler.ts
+++ b/src/handlers/connect.handler.ts
@@ -201,9 +201,9 @@ export async function disambiguateTargetName(
         } else {
             // ambiguous target id, warn user, exit process
             logger.warn(`Multiple ${parsedTarget.type} targets found with name ${parsedTarget.name}`);
-            const tableString = getTableOfTargets(matchedNamedTargets, await envs);
+            const tableString = getTableOfTargets(matchedNamedTargets, await envs, true);
             console.log(tableString);
-            logger.info('Please connect using \'target id\' instead of target name');
+            logger.info('Please connect using the target\'s id instead of target name');
             await cleanExit(1, logger);
         }
     }

--- a/src/handlers/copy.handler.ts
+++ b/src/handlers/copy.handler.ts
@@ -2,11 +2,12 @@ import { FileService, PolicyQueryService } from '../http.service/http.service';
 import { ConfigService } from '../config.service/config.service';
 import { Logger } from '../logger.service/logger';
 import { cleanExit } from './clean-exit.handler';
-import fs from 'fs';
 import { ParsedTargetString, TargetType } from '../types';
 import { targetStringExampleNoPath } from '../utils';
 import { VerbType } from '../http.service/http.service.types';
+
 import _ from 'lodash';
+import fs from 'fs';
 
 
 export async function copyHandler(
@@ -42,8 +43,8 @@ export async function copyHandler(
 
     if(parsedTarget.type == TargetType.DYNAMIC)
     {
-        this.logger.error('Cannot file transfer with a dynamic access config');
-        this.logger.warn('Please create a new dynamic access target or fetch an existing one (zli lt)');
+        logger.error('Cannot file transfer with a dynamic access config');
+        logger.warn('Please create a new dynamic access target or fetch an existing one (zli lt)');
         cleanExit(1, this.logger);
     }
 

--- a/src/handlers/copy.handler.ts
+++ b/src/handlers/copy.handler.ts
@@ -35,7 +35,7 @@ export async function copyHandler(
 
     const allowedTargetUsers = response.allowedTargetUsers.map(u => u.userName);
     if(response.allowedTargetUsers && ! _.includes(allowedTargetUsers, parsedTarget.user)) {
-        logger.error(`You do not have permission to connect as targetUser: ${parsedTarget.user}`);
+        logger.error(`You do not have permission to file transfer as targetUser: ${parsedTarget.user}`);
         logger.info(`Current allowed users for you: ${allowedTargetUsers}`);
         cleanExit(1, logger);
     }

--- a/src/handlers/copy.handler.ts
+++ b/src/handlers/copy.handler.ts
@@ -1,74 +1,53 @@
-import {
-    parseTargetString,
-    targetStringExample,
-    TargetSummary
-} from '../utils';
 import { FileService } from '../http.service/http.service';
 import { ConfigService } from '../config.service/config.service';
 import { Logger } from '../logger.service/logger';
 import { cleanExit } from './clean-exit.handler';
-
 import fs from 'fs';
-import { disambiguateTargetName } from './connect.handler';
-import { EnvironmentDetails } from '../http.service/http.service.types';
-import { TargetType } from '../types';
+import { ParsedTargetString, TargetType } from '../types';
+import { targetStringExampleNoPath } from '../utils';
 
 
 export async function copyHandler(
     configService: ConfigService,
     logger: Logger,
-    argv: any,
-    dynamicConfigs: Promise<TargetSummary[]>,
-    ssmTargets: Promise<TargetSummary[]>,
-    sshTargets: Promise<TargetSummary[]>,
-    envs: Promise<EnvironmentDetails[]>) {
-
-    const sourceParsedString = parseTargetString(argv.targetType, argv.source);
-    const destParsedString = parseTargetString(argv.targetType, argv.destination);
-
-    if(! sourceParsedString && ! destParsedString)
-    {
-        logger.error('Either source or destination must be a valid target string');
-        cleanExit(1, logger);
-    }
-
-    const sourceOrDest = !! sourceParsedString ? argv.source : argv.destination;
-
-    const parsedTarget = await disambiguateTargetName(argv.targetType, sourceOrDest, logger, dynamicConfigs, ssmTargets, sshTargets, envs);
-
-    // Given the command level parsing only accepts ssm and ssh
-    // we should not expect to his this code block
-    if(parsedTarget.type == TargetType.DYNAMIC)
-    {
-        logger.error('Cannot file transfer with a dynamic access config');
-        logger.warn('Please create a new dynamic access target or fetch an existing one (zli lt)');
-        cleanExit(1, logger);
-    }
+    parsedTarget: ParsedTargetString,
+    localFilePath: string,
+    isTargetSource: boolean) {
 
     const fileService = new FileService(configService, logger);
 
+    if(! parsedTarget) {
+        logger.error('No targets matched your targetName/targetId or invalid target string, must follow syntax:');
+        logger.error(targetStringExampleNoPath);
+        await cleanExit(1, logger);
+    }
+
+    if(parsedTarget.type == TargetType.DYNAMIC)
+    {
+        this.logger.error('Cannot file transfer with a dynamic access config');
+        this.logger.warn('Please create a new dynamic access target or fetch an existing one (zli lt)');
+        cleanExit(1, this.logger);
+    }
+
     // figure out upload or download
     // would be undefined if not parsed properly
-    if(!! destParsedString)
+    if(isTargetSource)
     {
         // Upload case
         // First ensure that the file exists
-        if (!fs.existsSync(argv.source)) {
-            logger.warn(`File ${argv.source} does not exist!`);
+        if (!fs.existsSync(localFilePath)) {
+            logger.warn(`File ${localFilePath} does not exist!`);
             process.exit(1);
         }
 
         // Then create our read stream and try to upload it
-        const fh = fs.createReadStream(argv.source);
+        const fh = fs.createReadStream(localFilePath);
         await fileService.uploadFile(parsedTarget.id, parsedTarget.type, parsedTarget.path, fh, parsedTarget.user);
         logger.info('File upload complete');
 
-    } else if(!! sourceParsedString) {
-    // download case
-        await fileService.downloadFile(parsedTarget.id, parsedTarget.type, parsedTarget.path, argv.destination, parsedTarget.user);
     } else {
-        logger.error('Invalid target string, must follow syntax:');
-        logger.error(targetStringExample);
+    // download case
+        await fileService.downloadFile(parsedTarget.id, parsedTarget.type, parsedTarget.path, localFilePath, parsedTarget.user);
     }
     await cleanExit(0, logger);
 }

--- a/src/handlers/copy.handler.ts
+++ b/src/handlers/copy.handler.ts
@@ -1,10 +1,12 @@
-import { FileService } from '../http.service/http.service';
+import { FileService, PolicyQueryService } from '../http.service/http.service';
 import { ConfigService } from '../config.service/config.service';
 import { Logger } from '../logger.service/logger';
 import { cleanExit } from './clean-exit.handler';
 import fs from 'fs';
 import { ParsedTargetString, TargetType } from '../types';
 import { targetStringExampleNoPath } from '../utils';
+import { VerbType } from '../http.service/http.service.types';
+import _ from 'lodash';
 
 
 export async function copyHandler(
@@ -20,6 +22,22 @@ export async function copyHandler(
         logger.error('No targets matched your targetName/targetId or invalid target string, must follow syntax:');
         logger.error(targetStringExampleNoPath);
         await cleanExit(1, logger);
+    }
+
+    const policyQueryService = new PolicyQueryService(configService, logger);
+    const response = await policyQueryService.ListTargetUsers(parsedTarget.id, parsedTarget.type, {type: VerbType.FileTransfer}, undefined);
+
+    if(! response.allowed)
+    {
+        logger.error('You do not have sufficient permission to file transfer with the target');
+        cleanExit(1, logger);
+    }
+
+    const allowedTargetUsers = response.allowedTargetUsers.map(u => u.userName);
+    if(response.allowedTargetUsers && ! _.includes(allowedTargetUsers, parsedTarget.user)) {
+        logger.error(`You do not have permission to connect as targetUser: ${parsedTarget.user}`);
+        logger.info(`Current allowed users for you: ${allowedTargetUsers}`);
+        cleanExit(1, logger);
     }
 
     if(parsedTarget.type == TargetType.DYNAMIC)

--- a/src/handlers/list-targets.handler.ts
+++ b/src/handlers/list-targets.handler.ts
@@ -1,5 +1,4 @@
 import {
-    TargetSummary,
     findSubstring,
     parseTargetType,
     getTableOfTargets
@@ -7,6 +6,7 @@ import {
 import { Logger } from '../logger.service/logger';
 import { EnvironmentDetails } from '../http.service/http.service.types';
 import { cleanExit } from './clean-exit.handler';
+import { TargetSummary } from '../types';
 
 
 export async function listTargetsHandler(

--- a/src/handlers/list-targets.handler.ts
+++ b/src/handlers/list-targets.handler.ts
@@ -23,27 +23,30 @@ export async function listTargetsHandler(
     // find all envIds with substring search
     // filter targets down by endIds
     // ref for '!!': https://stackoverflow.com/a/29312197/14782428
-    if(!! argv.env)
-    {
+    if(!! argv.env) {
         const envIdFilter = envs.filter(e => findSubstring(argv.env, e.name)).map(e => e.id);
-
         allTargets = allTargets.filter(t => envIdFilter.includes(t.environmentId));
     }
 
     // filter targets by name/alias
-    if(!! argv.name)
-    {
+    if(!! argv.name) {
         allTargets = allTargets.filter(t => findSubstring(argv.name, t.name));
     }
 
     // filter targets by TargetType
-    if(!! argv.targetType)
-    {
+    if(!! argv.targetType) {
         const targetType = parseTargetType(argv.targetType);
         allTargets = allTargets.filter(t => t.type === targetType);
     }
 
-    const tableString = getTableOfTargets(allTargets, envs, !! argv.showId);
-    console.log(tableString);
+    if(!! argv.json) {
+        // json output
+        console.log(JSON.stringify(allTargets));
+    } else {
+        // regular table output
+        const tableString = getTableOfTargets(allTargets, envs, !! argv.showId);
+        console.log(tableString);
+    }
+
     await cleanExit(0, logger);
 }

--- a/src/handlers/list-targets.handler.ts
+++ b/src/handlers/list-targets.handler.ts
@@ -43,7 +43,7 @@ export async function listTargetsHandler(
         allTargets = allTargets.filter(t => t.type === targetType);
     }
 
-    const tableString = getTableOfTargets(allTargets, envs);
+    const tableString = getTableOfTargets(allTargets, envs, !! argv.showId);
     console.log(tableString);
     await cleanExit(0, logger);
 }

--- a/src/handlers/list-targets.handler.ts
+++ b/src/handlers/list-targets.handler.ts
@@ -44,7 +44,7 @@ export async function listTargetsHandler(
         console.log(JSON.stringify(allTargets));
     } else {
         // regular table output
-        const tableString = getTableOfTargets(allTargets, envs, !! argv.showId);
+        const tableString = getTableOfTargets(allTargets, envs, !! argv.detail , !! argv.showId);
         console.log(tableString);
     }
 

--- a/src/handlers/login.handler.ts
+++ b/src/handlers/login.handler.ts
@@ -1,13 +1,13 @@
 import { ConfigService } from '../config.service/config.service';
 import { Logger } from '../logger.service/logger';
 import { OAuthService } from '../oauth.service/oauth.service';
-import { IdP } from '../types';
 import { MfaService, UserService } from '../http.service/http.service';
 import { MfaActionRequired } from '../http.service/http.service.types';
 import { cleanExit } from './clean-exit.handler';
 import { KeySplittingService } from '../../webshell-common-ts/keysplitting.service/keysplitting.service';
 
 import qrcode from 'qrcode';
+import { IdP } from '../types';
 
 
 export async function loginHandler(configService: ConfigService, logger: Logger, argv: any, keySplittingService: KeySplittingService) {
@@ -17,6 +17,9 @@ export async function loginHandler(configService: ConfigService, logger: Logger,
 
     const provider = <IdP> argv.provider;
     await configService.loginSetup(provider);
+
+    // const oAuthService = new OAuthService(configService, logger);
+    // await oAuthService.idpSelect(async (idp) => await configService.loginSetup(idp));
 
     // Can only create oauth service after loginSetup completes
     const oAuthService = new OAuthService(configService, logger);

--- a/src/handlers/login.handler.ts
+++ b/src/handlers/login.handler.ts
@@ -18,9 +18,6 @@ export async function loginHandler(configService: ConfigService, logger: Logger,
     const provider = <IdP> argv.provider;
     await configService.loginSetup(provider);
 
-    // const oAuthService = new OAuthService(configService, logger);
-    // await oAuthService.idpSelect(async (idp) => await configService.loginSetup(idp));
-
     // Can only create oauth service after loginSetup completes
     const oAuthService = new OAuthService(configService, logger);
     if(! oAuthService.isAuthenticated())

--- a/src/handlers/middleware.handler.ts
+++ b/src/handlers/middleware.handler.ts
@@ -6,8 +6,7 @@ import {
     SshTargetService,
     SsmTargetService
 } from '../http.service/http.service';
-import { TargetSummary } from '../utils';
-import { TargetType } from '../types';
+import { TargetSummary, TargetType } from '../types';
 import { MixpanelService } from '../mixpanel.service/mixpanel.service';
 import { version } from '../../package.json';
 import { oauthMiddleware } from '../middlewares/oauth-middleware';

--- a/src/handlers/middleware.handler.ts
+++ b/src/handlers/middleware.handler.ts
@@ -24,7 +24,7 @@ export function fetchDataMiddleware(configService: ConfigService, logger: Logger
     const dynamicConfigs = dynamicConfigService.ListDynamicAccessConfigs()
         .then(result =>
             result.map<TargetSummary>((config, _index, _array) => {
-                return {type: TargetType.DYNAMIC, id: config.id, name: config.name, environmentId: config.environmentId};
+                return {type: TargetType.DYNAMIC, id: config.id, name: config.name, environmentId: config.environmentId, agentVersion: 'N/A', status: 'N/A'};
             })
         );
 
@@ -34,7 +34,7 @@ export function fetchDataMiddleware(configService: ConfigService, logger: Logger
     const ssmTargets = ssmTargetService.ListSsmTargets(true)
         .then(result =>
             result.map<TargetSummary>((ssm, _index, _array) => {
-                return {type: TargetType.SSM, id: ssm.id, name: ssm.name, environmentId: ssm.environmentId};
+                return {type: TargetType.SSM, id: ssm.id, name: ssm.name, environmentId: ssm.environmentId, agentVersion: ssm.agentVersion, status: ssm.status};
             })
         );
 
@@ -42,7 +42,7 @@ export function fetchDataMiddleware(configService: ConfigService, logger: Logger
     const sshTargets = sshTargetService.ListSshTargets()
         .then(result =>
             result.map<TargetSummary>((ssh, _index, _array) => {
-                return {type: TargetType.SSH, id: ssh.id, name: ssh.alias, environmentId: ssh.environmentId};
+                return {type: TargetType.SSH, id: ssh.id, name: ssh.alias, environmentId: ssh.environmentId, agentVersion: 'N/A', status: 'N/A'};
             })
         );
 

--- a/src/handlers/ssh-proxy.handler.ts
+++ b/src/handlers/ssh-proxy.handler.ts
@@ -28,7 +28,7 @@ export async function sshProxyHandler(configService: ConfigService, logger: Logg
         cleanExit(1, logger);
     }
 
-    let ssmTunnelService = new SsmTunnelService(logger, configService, keySplittingService, envMap['enableKeysplitting'] == 'true');
+    const ssmTunnelService = new SsmTunnelService(logger, configService, keySplittingService, envMap['enableKeysplitting'] == 'true');
     ssmTunnelService.errors.subscribe(async errorMessage => {
         process.stderr.write(`\n${errorMessage}\n`);
         await cleanExit(1, logger);

--- a/src/handlers/ssh-proxy.handler.ts
+++ b/src/handlers/ssh-proxy.handler.ts
@@ -6,16 +6,23 @@ import { cleanExit } from './clean-exit.handler';
 import { Dictionary } from 'lodash';
 
 
-export async function sshProxyHandler(configService: ConfigService, logger: Logger, argv: any, keySplittingService: KeySplittingService, envMap: Dictionary<string>) {
-    const ssmTunnelService = new SsmTunnelService(logger, configService, keySplittingService, envMap['enableKeysplitting'] == 'true');
+export async function sshProxyHandler(configService: ConfigService, logger: Logger, sshTunnelParameters: SshTunnelParameters, keySplittingService: KeySplittingService, envMap: Dictionary<string>) {
+    let ssmTunnelService = new SsmTunnelService(logger, configService, keySplittingService, envMap['enableKeysplitting'] == 'true');
     ssmTunnelService.errors.subscribe(async errorMessage => {
         process.stderr.write(`\n${errorMessage}\n`);
         await cleanExit(1, logger);
     });
 
-    if( await ssmTunnelService.setupWebsocketTunnel(argv.host, argv.user, argv.port, argv.identityFile)) {
+    if( await ssmTunnelService.setupWebsocketTunnel(sshTunnelParameters.host, sshTunnelParameters.user, sshTunnelParameters.port, sshTunnelParameters.identityFile)) {
         process.stdin.on('data', async (data) => {
             ssmTunnelService.sendData(data);
         });
     }
+}
+
+export interface SshTunnelParameters {
+    host: string;
+    user: string;
+    port: number;
+    identityFile: string;
 }

--- a/src/handlers/ssh-proxy.handler.ts
+++ b/src/handlers/ssh-proxy.handler.ts
@@ -4,16 +4,37 @@ import { Logger } from '../logger.service/logger';
 import { SsmTunnelService } from '../ssm-tunnel/ssm-tunnel.service';
 import { cleanExit } from './clean-exit.handler';
 import { Dictionary } from 'lodash';
+import { PolicyQueryService } from '../http.service/http.service';
+import { ParsedTargetString } from '../types';
+import _ from 'lodash';
+import { VerbType } from '../http.service/http.service.types';
 
 
 export async function sshProxyHandler(configService: ConfigService, logger: Logger, sshTunnelParameters: SshTunnelParameters, keySplittingService: KeySplittingService, envMap: Dictionary<string>) {
+
+    const policyQueryService = new PolicyQueryService(configService, logger);
+    const response = await policyQueryService.ListTargetUsers(sshTunnelParameters.parsedTarget.id, sshTunnelParameters.parsedTarget.type, {type: VerbType.Tunnel}, undefined);
+
+    if(! response.allowed)
+    {
+        logger.error('You do not have sufficient permission to file transfer with the target');
+        cleanExit(1, logger);
+    }
+
+    const allowedTargetUsers = response.allowedTargetUsers.map(u => u.userName);
+    if(response.allowedTargetUsers && ! _.includes(allowedTargetUsers, sshTunnelParameters.parsedTarget.user)) {
+        logger.error(`You do not have permission to tunnel as targetUser: ${sshTunnelParameters.parsedTarget.user}`);
+        logger.info(`Current allowed users for you: ${allowedTargetUsers}`);
+        cleanExit(1, logger);
+    }
+
     let ssmTunnelService = new SsmTunnelService(logger, configService, keySplittingService, envMap['enableKeysplitting'] == 'true');
     ssmTunnelService.errors.subscribe(async errorMessage => {
         process.stderr.write(`\n${errorMessage}\n`);
         await cleanExit(1, logger);
     });
 
-    if( await ssmTunnelService.setupWebsocketTunnel(sshTunnelParameters.host, sshTunnelParameters.user, sshTunnelParameters.port, sshTunnelParameters.identityFile)) {
+    if( await ssmTunnelService.setupWebsocketTunnel(sshTunnelParameters.parsedTarget, sshTunnelParameters.port, sshTunnelParameters.identityFile)) {
         process.stdin.on('data', async (data) => {
             ssmTunnelService.sendData(data);
         });
@@ -21,8 +42,7 @@ export async function sshProxyHandler(configService: ConfigService, logger: Logg
 }
 
 export interface SshTunnelParameters {
-    host: string;
-    user: string;
+    parsedTarget: ParsedTargetString;
     port: number;
     identityFile: string;
 }

--- a/src/http.service/http.service.ts
+++ b/src/http.service/http.service.ts
@@ -424,6 +424,6 @@ export class PolicyQueryService extends HttpService
             targetUser: targetUser
         };
 
-        return this.Post('target-connect', request)
+        return this.Post('target-connect', request);
     }
 }

--- a/src/http.service/http.service.ts
+++ b/src/http.service/http.service.ts
@@ -1,7 +1,7 @@
 import { IdP, TargetType } from '../types';
 import got, { Got, HTTPError } from 'got/dist/source';
 import { Dictionary } from 'lodash';
-import { ClientSecretResponse, CloseConnectionRequest, CloseSessionRequest, CloseSessionResponse, ConnectionSummary, CreateConnectionRequest, CreateConnectionResponse, CreateSessionRequest, CreateSessionResponse, DownloadFileRequest, DynamicAccessConfigSummary, EnvironmentDetails, ListSessionsResponse, ListSsmTargetsRequest, MfaClearRequest, MfaResetResponse, MfaTokenRequest, MixpanelTokenResponse, SessionDetails, SshTargetSummary, SsmTargetSummary, UploadFileRequest, UploadFileResponse, UserRegisterResponse, UserSummary } from './http.service.types';
+import { ClientSecretResponse, CloseConnectionRequest, CloseSessionRequest, CloseSessionResponse, ConnectionSummary, CreateConnectionRequest, CreateConnectionResponse, CreateSessionRequest, CreateSessionResponse, DownloadFileRequest, DynamicAccessConfigSummary, EnvironmentDetails, GetTargetPolicyRequest, GetTargetPolicyResponse, ListSessionsResponse, ListSsmTargetsRequest, MfaClearRequest, MfaResetResponse, MfaTokenRequest, MixpanelTokenResponse, SessionDetails, SshTargetSummary, SsmTargetSummary, TargetUser, UploadFileRequest, UploadFileResponse, UserRegisterResponse, UserSummary, Verb } from './http.service.types';
 import { ConfigService } from '../config.service/config.service';
 import fs, { ReadStream } from 'fs';
 import FormData from 'form-data';
@@ -405,5 +405,25 @@ export class DynamicAccessConfigService extends HttpService
     public ListDynamicAccessConfigs(): Promise<DynamicAccessConfigSummary[]>
     {
         return this.Post('list', {});
+    }
+}
+
+export class PolicyQueryService extends HttpService
+{
+    constructor(configService: ConfigService, logger: Logger)
+    {
+        super(configService, 'api/v1/policy-query', logger);
+    }
+
+    public ListTargetUsers(targetId: string, targetType: TargetType, verb?: Verb, targetUser?: TargetUser): Promise<GetTargetPolicyResponse>
+    {
+        const request: GetTargetPolicyRequest = {
+            targetId: targetId,
+            targetType: targetType,
+            verb: verb,
+            targetUser: targetUser
+        };
+
+        return this.Post('target-connect', request)
     }
 }

--- a/src/http.service/http.service.types.ts
+++ b/src/http.service/http.service.types.ts
@@ -216,3 +216,34 @@ export interface DynamicAccessConfigSummary
     name: string;
     environmentId: string;
 }
+
+export interface GetTargetPolicyResponse
+{
+    allowed: boolean;
+    allowedTargetUsers: TargetUser[];
+    allowedVerbs: Verb[]
+}
+
+export interface TargetUser
+{
+    userName: string;
+}
+
+export interface Verb
+{
+    type: VerbType;
+}
+
+export interface GetTargetPolicyRequest
+{
+    targetId: string;
+    targetType: TargetType;
+    verb?: Verb;
+    targetUser?: TargetUser;
+}
+
+export enum VerbType {
+    Shell = 'Shell',
+    FileTransfer = 'FileTransfer',
+    Tunnel = 'Tunnel'
+}

--- a/src/oauth.service/oauth.service.ts
+++ b/src/oauth.service/oauth.service.ts
@@ -5,9 +5,8 @@ import { ConfigService } from '../config.service/config.service';
 import http, { RequestListener } from 'http';
 import { setTimeout } from 'timers';
 import { Logger } from '../../src/logger.service/logger';
-import { IdP } from '../types';
-import fs from 'fs';
-import path from 'path';
+import { loginHtml } from './templates/login';
+import { logoutHtml } from './templates/logout';
 
 export class OAuthService implements IDisposable {
     private server: http.Server; // callback listener
@@ -45,14 +44,15 @@ export class OAuthService implements IDisposable {
                 // write to config with callback
                 callback(tokenSet);
                 this.server.close();
-                fs.createReadStream(path.join(__dirname, './templates/login.html')).pipe(res);
+                res.write(loginHtml);
                 resolve();
                 break;
 
             case '/logout-callback':
                 this.logger.info('Login successful');
                 this.logger.debug('callback listener closed');
-                fs.createReadStream(path.join(__dirname, './templates/logout.html')).pipe(res);
+                this.server.close();
+                res.write(logoutHtml);
                 resolve();
                 break;
 

--- a/src/oauth.service/templates/login.ts
+++ b/src/oauth.service/templates/login.ts
@@ -1,6 +1,6 @@
-<html>
+export const loginHtml = `<html>
     <head>
-        <title>Logout Successful</title>
+        <title>Login Successful</title>
         <link rel="icon" type="image/png" href="https://cloud.bastionzero.com/assets/icons/favicon_light.png">
         <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
         <style>
@@ -23,7 +23,7 @@
         <div class="center-div">
             <img src="https://cloud.bastionzero.com/assets/icons/Wordmark-Horizontal.png" height="28px">
             <br>
-            <p class="text">Log out successful. You may close this window.</p>
+            <p class="text">Log in successful. You may close this window.</p>
         </div>
     </body>
-</html>
+</html>`;

--- a/src/oauth.service/templates/logout.html
+++ b/src/oauth.service/templates/logout.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>Logout Successful</title>
-        <link rel="icon" type="image/png" href="https://app.bastionzero.com/assets/icons/favicon_light.png">
+        <link rel="icon" type="image/png" href="https://cloud.bastionzero.com/assets/icons/favicon_light.png">
         <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
         <style>
             .center-div {
@@ -21,7 +21,7 @@
     </head>
     <body style="background-color:#242424;">
         <div class="center-div">
-            <img src="https://app.bastionzero.com/assets/icons/Wordmark-Horizontal.png" height="28px">
+            <img src="https://cloud.bastionzero.com/assets/icons/Wordmark-Horizontal.png" height="28px">
             <br>
             <p class="text">Log out successful. You may close this window.</p>
         </div>

--- a/src/oauth.service/templates/logout.ts
+++ b/src/oauth.service/templates/logout.ts
@@ -1,6 +1,6 @@
-<html>
+export const logoutHtml = `<html>
     <head>
-        <title>Login Successful</title>
+        <title>Logout Successful</title>
         <link rel="icon" type="image/png" href="https://cloud.bastionzero.com/assets/icons/favicon_light.png">
         <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
         <style>
@@ -23,7 +23,7 @@
         <div class="center-div">
             <img src="https://cloud.bastionzero.com/assets/icons/Wordmark-Horizontal.png" height="28px">
             <br>
-            <p class="text">Log in successful. You may close this window.</p>
+            <p class="text">Log out successful. You may close this window.</p>
         </div>
     </body>
-</html>
+</html>`;

--- a/src/ssm-tunnel/ssm-tunnel.service.ts
+++ b/src/ssm-tunnel/ssm-tunnel.service.ts
@@ -11,7 +11,6 @@ import { ConfigService } from '../config.service/config.service';
 import { KeySplittingService } from '../../webshell-common-ts/keysplitting.service/keysplitting.service';
 
 import { SsmTargetService } from '../http.service/http.service';
-import { SsmTargetSummary } from '../http.service/http.service.types';
 import { SsmTunnelWebsocketService } from '../../webshell-common-ts/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service';
 import { ZliAuthConfigService } from '../config.service/zli-auth-config.service';
 import { SsmTunnelTargetInfo } from '../../webshell-common-ts/ssm-tunnel-websocket.service/ssm-tunnel-websocket.types';
@@ -53,7 +52,7 @@ export class SsmTunnelService
             // target is ssmtargetsummary
             const ssmTargetService = new SsmTargetService(this.configService, this.logger);
             const target = await ssmTargetService.GetSsmTarget(parsedTarget.id);
-            
+
             this.ssmTunnelWebsocketService = new SsmTunnelWebsocketService(
                 this.logger,
                 this.keySplittingService,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,22 @@ export enum IdP {
     Google = 'Google',
     Microsoft = 'Microsoft'
 }
+
+export interface TargetSummary
+{
+    id: string;
+    name: string;
+    environmentId: string;
+    type: TargetType;
+}
+
+export interface ParsedTargetString
+{
+    type: TargetType;
+    user: string;
+    id: string;
+    name: string;
+    path: string;
+    envId: string;
+    envName: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface TargetSummary
     name: string;
     environmentId: string;
     type: TargetType;
+    agentVersion: string;
+    status: string;
 }
 
 export interface ParsedTargetString

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,14 +110,15 @@ export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDet
 // Figure out target id based on target name and target type.
 // Also preforms error checking on target type and target string passed in
 export async function disambiguateTarget(
-    argv: any,
+    targetTypeString: string,
+    targetString: string,
     logger: Logger,
     dynamicConfigs: Promise<TargetSummary[]>,
     ssmTargets: Promise<TargetSummary[]>,
     sshTargets: Promise<TargetSummary[]>,
     envs: Promise<EnvironmentDetails[]>): Promise<ParsedTargetString> {
 
-    let parsedTarget = parseTargetString(argv.targetString);
+    let parsedTarget = parseTargetString(targetString);
 
     if(! parsedTarget) {
         return undefined;
@@ -125,8 +126,8 @@ export async function disambiguateTarget(
 
     let zippedTargets = _.concat(await ssmTargets, await sshTargets, await dynamicConfigs);
 
-    if(!! argv.targetType) {
-        let targetType = parseTargetType(argv.targetType);
+    if(!! targetTypeString) {
+        let targetType = parseTargetType(targetTypeString);
         zippedTargets = zippedTargets.filter(t => t.type == targetType);
     }
 
@@ -140,8 +141,6 @@ export async function disambiguateTarget(
 
     if(matchedTargets.length == 0) {
         return undefined;
-        // logger.error('No targets match that name, please check your targetUser, targetName/targetId');
-        // cleanExit(1, logger);
     } else if(matchedTargets.length == 1) {
         parsedTarget.id = matchedTargets[0].id;
         parsedTarget.name = matchedTargets[0].name;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,10 @@
-import { TargetType } from './types';
+import { ParsedTargetString, TargetSummary, TargetType } from './types';
 import { max } from 'lodash';
 import { EnvironmentDetails } from './http.service/http.service.types';
 import Table from 'cli-table3';
+import { Logger } from './logger.service/logger';
+import { cleanExit } from './handlers/clean-exit.handler';
+import _ from 'lodash';
 
 // case insensitive substring search, 'find targetString in searchString'
 export function findSubstring(targetString: string, searchString: string) : boolean
@@ -9,8 +12,8 @@ export function findSubstring(targetString: string, searchString: string) : bool
     return searchString.toLowerCase().indexOf(targetString.toLowerCase()) !== -1;
 }
 
-export const targetStringExample: string = '[targetUser@]<targetId | targetName>:<targetPath>';
-export const targetStringExampleNoPath : string = '[targetUser@]<targetId | targetName>';
+export const targetStringExample: string = '[targetUser@]<targetId-or-targetName>:<targetPath>';
+export const targetStringExampleNoPath : string = '[targetUser@]<targetId-or-targetName>';
 
 export function parseTargetType(targetType: string) : TargetType
 {
@@ -22,22 +25,22 @@ export function parseTargetType(targetType: string) : TargetType
     return <TargetType> targetType.toUpperCase();
 }
 
-export function parseTargetString(targetTypeString: string , targetString: string) : parsedTargetString
+export function parseTargetString(targetString: string) : ParsedTargetString
 {
-    const targetType = parseTargetType(targetTypeString);
-
     // case sensitive check for [targetUser@]<targetId | targetName>[:targetPath]
     const pattern = /^([a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)@)?(([0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})|([a-zA-Z0-9_.-]{1,255}))(:{1}|$)/;
 
     if(! pattern.test(targetString))
         return undefined;
 
-    const result : parsedTargetString = {
-        type: targetType,
+    let result : ParsedTargetString = {
+        type: undefined,
         user: undefined,
         id: undefined,
         name: undefined,
-        path: undefined
+        path: undefined,
+        envId: undefined,
+        envName: undefined
     };
 
     let atSignSplit = targetString.split('@', 2);
@@ -66,16 +69,7 @@ export function parseTargetString(targetTypeString: string , targetString: strin
     return result;
 }
 
-export interface parsedTargetString
-{
-    type: TargetType;
-    user: string;
-    id: string;
-    name: string;
-    path: string;
-}
-
-export function checkTargetTypeAndStringPair(parsedTarget: parsedTargetString) : boolean
+export function checkTargetTypeAndStringPair(parsedTarget: ParsedTargetString) : boolean
 {
     if(parsedTarget.type === TargetType.SSH && parsedTarget.user)
         return false;
@@ -86,23 +80,15 @@ export function checkTargetTypeAndStringPair(parsedTarget: parsedTargetString) :
     return true;
 }
 
-export interface TargetSummary
-{
-    id: string;
-    name: string;
-    environmentId: string;
-    type: TargetType;
-}
-
 export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[], showGuid: boolean = false) : string
 {
     const targetNameLength = max(targets.map(t => t.name.length).concat(16)); // if max is 0 then use 16 as width
     const envNameLength = max(envs.map(e => e.name.length).concat(16));       // same same
 
     let header: string[] = ['Type', 'Name', 'Environment'];
-    let columnWidths = [10, targetNameLength + 2, envNameLength + 2]
+    let columnWidths = [10, targetNameLength + 2, envNameLength + 2];
 
-    if(showGuid) 
+    if(showGuid)
     {
         header.push('Id');
         columnWidths.push(38);
@@ -112,11 +98,61 @@ export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDet
     var table = new Table({ head: header, colWidths: columnWidths });
 
     targets.forEach(target => {
-            let row = [target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name];
-            if(showGuid) row.push(target.id);
-            table.push(row);
-        }
+        let row = [target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name];
+        if(showGuid) row.push(target.id);
+        table.push(row);
+    }
     );
 
     return table.toString();
+}
+
+// Figure out target id based on target name and target type.
+// Also preforms error checking on target type and target string passed in
+export async function disambiguateTarget(
+    argv: any,
+    logger: Logger,
+    dynamicConfigs: Promise<TargetSummary[]>,
+    ssmTargets: Promise<TargetSummary[]>,
+    sshTargets: Promise<TargetSummary[]>,
+    envs: Promise<EnvironmentDetails[]>): Promise<ParsedTargetString> {
+
+    let parsedTarget = parseTargetString(argv.targetString);
+
+    if(! parsedTarget) {
+        return undefined;
+    }
+
+    let zippedTargets = _.concat(await ssmTargets, await sshTargets, await dynamicConfigs);
+
+    if(!! argv.targetType) {
+        let targetType = parseTargetType(argv.targetType);
+        zippedTargets = zippedTargets.filter(t => t.type == targetType);
+    }
+
+    let matchedTargets: TargetSummary[];
+
+    if(!! parsedTarget.id) {
+        matchedTargets = zippedTargets.filter(t => t.id == parsedTarget.id);
+    } else if(!! parsedTarget.name) {
+        matchedTargets = zippedTargets.filter(t => t.name == parsedTarget.name);
+    }
+
+    if(matchedTargets.length == 0) {
+        return undefined;
+        // logger.error('No targets match that name, please check your targetUser, targetName/targetId');
+        // cleanExit(1, logger);
+    } else if(matchedTargets.length == 1) {
+        parsedTarget.id = matchedTargets[0].id;
+        parsedTarget.name = matchedTargets[0].name;
+        parsedTarget.type = matchedTargets[0].type;
+        parsedTarget.envId = matchedTargets[0].environmentId;
+        parsedTarget.envName = (await envs).filter(e => e.id == parsedTarget.envId)[0].name;
+    } else {
+        logger.warn('More than one target found with the same targetName');
+        logger.info(`Please specify the targetId instead of the targetName (zli lt -n ${parsedTarget.name} -d)`);
+        cleanExit(1, logger);
+    }
+
+    return parsedTarget;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export function checkTargetTypeAndStringPair(parsedTarget: ParsedTargetString) :
     return true;
 }
 
-export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[], showGuid: boolean = false) : string
+export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[], showDetail: boolean = false, showGuid: boolean = false) : string
 {
     const targetNameLength = max(targets.map(t => t.name.length).concat(16)); // if max is 0 then use 16 as width
     const envNameLength = max(envs.map(e => e.name.length).concat(16));       // same same
@@ -94,12 +94,27 @@ export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDet
         columnWidths.push(38);
     }
 
+    if(showDetail)
+    {
+        header.push('Agent Version', 'Status');
+        columnWidths.push(15, 10);
+    }
+
     // ref: https://github.com/cli-table/cli-table3
     const table = new Table({ head: header, colWidths: columnWidths });
 
     targets.forEach(target => {
         const row = [target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name];
-        if(showGuid) row.push(target.id);
+
+        if(showGuid) {
+            row.push(target.id);
+        }
+
+        if(showDetail) {
+            row.push(target.agentVersion);
+            row.push(target.status);
+        }
+
         table.push(row);
     }
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function parseTargetString(targetString: string) : ParsedTargetString
     if(! pattern.test(targetString))
         return undefined;
 
-    let result : ParsedTargetString = {
+    const result : ParsedTargetString = {
         type: undefined,
         user: undefined,
         id: undefined,
@@ -85,8 +85,8 @@ export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDet
     const targetNameLength = max(targets.map(t => t.name.length).concat(16)); // if max is 0 then use 16 as width
     const envNameLength = max(envs.map(e => e.name.length).concat(16));       // same same
 
-    let header: string[] = ['Type', 'Name', 'Environment'];
-    let columnWidths = [10, targetNameLength + 2, envNameLength + 2];
+    const header: string[] = ['Type', 'Name', 'Environment'];
+    const columnWidths = [10, targetNameLength + 2, envNameLength + 2];
 
     if(showGuid)
     {
@@ -95,10 +95,10 @@ export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDet
     }
 
     // ref: https://github.com/cli-table/cli-table3
-    var table = new Table({ head: header, colWidths: columnWidths });
+    const table = new Table({ head: header, colWidths: columnWidths });
 
     targets.forEach(target => {
-        let row = [target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name];
+        const row = [target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name];
         if(showGuid) row.push(target.id);
         table.push(row);
     }
@@ -118,7 +118,7 @@ export async function disambiguateTarget(
     sshTargets: Promise<TargetSummary[]>,
     envs: Promise<EnvironmentDetails[]>): Promise<ParsedTargetString> {
 
-    let parsedTarget = parseTargetString(targetString);
+    const parsedTarget = parseTargetString(targetString);
 
     if(! parsedTarget) {
         return undefined;
@@ -127,7 +127,7 @@ export async function disambiguateTarget(
     let zippedTargets = _.concat(await ssmTargets, await sshTargets, await dynamicConfigs);
 
     if(!! targetTypeString) {
-        let targetType = parseTargetType(targetTypeString);
+        const targetType = parseTargetType(targetTypeString);
         zippedTargets = zippedTargets.filter(t => t.type == targetType);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,18 +94,29 @@ export interface TargetSummary
     type: TargetType;
 }
 
-export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[]) : string
+export function getTableOfTargets(targets: TargetSummary[], envs: EnvironmentDetails[], showGuid: boolean = false) : string
 {
     const targetNameLength = max(targets.map(t => t.name.length).concat(16)); // if max is 0 then use 16 as width
     const envNameLength = max(envs.map(e => e.name.length).concat(16));       // same same
 
-    // ref: https://github.com/cli-table/cli-table3
-    const table = new Table({
-        head: ['Type', 'Name', 'Environment', 'Id']
-        , colWidths: [10, targetNameLength + 2, envNameLength + 2, 38]
-    });
+    let header: string[] = ['Type', 'Name', 'Environment'];
+    let columnWidths = [10, targetNameLength + 2, envNameLength + 2]
 
-    targets.forEach(target => table.push([target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name, target.id]));
+    if(showGuid) 
+    {
+        header.push('Id');
+        columnWidths.push(38);
+    }
+
+    // ref: https://github.com/cli-table/cli-table3
+    var table = new Table({ head: header, colWidths: columnWidths });
+
+    targets.forEach(target => {
+            let row = [target.type, target.name, envs.filter(e => e.id == target.environmentId).pop().name];
+            if(showGuid) row.push(target.id);
+            table.push(row);
+        }
+    );
 
     return table.toString();
 }


### PR DESCRIPTION
Version 4.13.0

Change log: 
- New target name and id disambiguation that does not require target id and type to be used unless there is a collision, you can either use GUID or pass a -t /  --targetType  flag
- list-targets command now optionally shows GUID with -i / --showId  flag
- list-targets command now optionally shows SSM taget agent version and status, for other target types shows N/A
- list-targets command now has --json  flag to output pipeable json results, best used with --silent  flag to hide all other text output
- Policy checks are preformed before connect/file transfer/tunnel, you are warned if you do not have a valid policy for that verb, if the verb is valid you are warned if the target user is invalid and shown all valid target users
- Revised help examples