### PR TITLE
Ensure oauth middleware is awaited in case a token refresh is needed

### DIFF
--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -71,13 +71,13 @@ export class CliDriver
                 this.configService = initResponse.configService;
                 this.keySplittingService = initResponse.keySplittingService;
             })
-            .middleware(() => {
-                checkVersionMiddleware(this.logger);
+            .middleware(async () => {
+                await checkVersionMiddleware(this.logger);
             })
             .middleware(async (argv) => {
                 if(includes(this.noOauthCommands, argv._[0]))
                     return;
-                oAuthMiddleware(this.configService, this.logger);
+                await oAuthMiddleware(this.configService, this.logger);
             })
             .middleware(async (argv) => {
                 if(includes(this.noMixpanelCommands, argv._[0]))

--- a/src/handlers/middleware.handler.ts
+++ b/src/handlers/middleware.handler.ts
@@ -76,9 +76,9 @@ export function mixedPanelTrackingMiddleware(configService: ConfigService, argv:
     return mixedPanelService;
 }
 
-export function oAuthMiddleware(configService: ConfigService, logger: Logger) {
+export async function oAuthMiddleware(configService: ConfigService, logger: Logger) {
     // OAuth
-    oauthMiddleware(configService, logger);
+    await oauthMiddleware(configService, logger);
     const me = configService.me(); // if you have logged in, this should be set
     const sessionId = configService.sessionId();
     logger.info(`Logged in as: ${me.email}, bzero-id:${me.id}, session-id:${sessionId}`);


### PR DESCRIPTION
This fixes a bug where the ouath middleware wasnt being properly awaited in the pipeline causing api requests to be made before the ouath tokens had been refreshed and resulting in 401 errors. This regression was introduced in #65 when we refactored the cli driver code. 

When refresh was needed zli would just exit with the following error until user manually logged out/in:

```
/bin/zli-linux lt 
Logged in as: sebby@commonwealthcrypto.com, bzero-id:4f2c2811-e7bc-4fbb-ad1a-3837e32d1d26, session-id:6a0fd763-386e-4d68-97d8-fc21bd1aea93
Authentication Error:
Response code 401 (Unauthorized)
```