### PR TITLE
Add refresh OAuth id token functionality

### DIFF
--- a/src/config.service/zli-auth-config.service.ts
+++ b/src/config.service/zli-auth-config.service.ts
@@ -5,11 +5,15 @@ import { OAuthService } from '../../src/oauth.service/oauth.service';
 
 export class ZliAuthConfigService implements AuthConfigService {
 
+    private oauth: OAuthService;
+
     constructor(
         private configService: ConfigService,
         private logger: Logger
     )
-    {}
+    {
+        this.oauth = new OAuthService(this.configService, this.logger);
+    }
 
     getServiceUrl() {
         return this.configService.serviceUrl() + 'api/v1/';
@@ -20,7 +24,6 @@ export class ZliAuthConfigService implements AuthConfigService {
     }
 
     async getIdToken() {
-        const oauth = new OAuthService(this.configService, this.logger);
-        return oauth.getIdToken();
+        return await this.oauth.getIdToken();
     }
 }

--- a/src/config.service/zli-auth-config.service.ts
+++ b/src/config.service/zli-auth-config.service.ts
@@ -1,10 +1,13 @@
 import { AuthConfigService } from '../../webshell-common-ts/auth-config-service/auth-config.service';
 import { ConfigService } from './config.service';
+import { Logger } from '../logger.service/logger';
+import { OAuthService } from '../../src/oauth.service/oauth.service';
 
 export class ZliAuthConfigService implements AuthConfigService {
 
     constructor(
-        private configService: ConfigService
+        private configService: ConfigService,
+        private logger: Logger
     )
     {}
 
@@ -17,6 +20,7 @@ export class ZliAuthConfigService implements AuthConfigService {
     }
 
     async getIdToken() {
-        return this.configService.getAuth();
+        const oauth = new OAuthService(this.configService, this.logger);
+        return oauth.getIdToken();
     }
 }

--- a/src/middlewares/oauth-middleware.ts
+++ b/src/middlewares/oauth-middleware.ts
@@ -1,42 +1,10 @@
-import { errors } from 'openid-client';
 import { OAuthService } from '../oauth.service/oauth.service';
 import { ConfigService } from '../config.service/config.service';
 import { Logger } from '../../src/logger.service/logger';
-import { cleanExit } from '../../src/handlers/clean-exit.handler';
 
 export async function oauthMiddleware(configService: ConfigService, logger: Logger) : Promise<void> {
 
     const oauth = new OAuthService(configService, logger);
 
-    const tokenSet = configService.tokenSet();
-
-    // decide if we need to refresh or prompt user for login
-    if(tokenSet)
-    {
-        if(configService.tokenSet().expired())
-        {
-            try {
-                logger.debug('Refreshing oauth tokens');
-
-                const newTokenSet = await oauth.refresh();
-                configService.setTokenSet(newTokenSet);
-                logger.debug('Oauth tokens refreshed');
-            } catch(e) {
-                if(e instanceof errors.RPError || e instanceof errors.OPError) {
-                    logger.error('Stale log in detected');
-                    logger.info('You need to log in, please run \'zli login --help\'');
-                    configService.logout();
-                    cleanExit(1, logger);
-                } else {
-                    logger.error('Unexpected error during oauth refresh');
-                    logger.info('Please log in again');
-                    configService.logout();
-                    cleanExit(1, logger);
-                }
-            }
-        }
-    } else {
-        logger.warn('You need to log in, please run \'zli login --help\'');
-        process.exit(1);
-    }
+    await oauth.getIdToken();
 }

--- a/src/middlewares/oauth-middleware.ts
+++ b/src/middlewares/oauth-middleware.ts
@@ -6,7 +6,7 @@ import { cleanExit } from '../../src/handlers/clean-exit.handler';
 
 export async function oauthMiddleware(configService: ConfigService, logger: Logger) : Promise<void> {
 
-    const ouath = new OAuthService(configService, logger);
+    const oauth = new OAuthService(configService, logger);
 
     const tokenSet = configService.tokenSet();
 
@@ -18,7 +18,7 @@ export async function oauthMiddleware(configService: ConfigService, logger: Logg
             try {
                 logger.debug('Refreshing oauth tokens');
 
-                const newTokenSet = await ouath.refresh();
+                const newTokenSet = await oauth.refresh();
                 configService.setTokenSet(newTokenSet);
                 logger.debug('Oauth tokens refreshed');
             } catch(e) {

--- a/src/oauth.service/oauth.service.ts
+++ b/src/oauth.service/oauth.service.ts
@@ -162,7 +162,7 @@ export class OAuthService implements IDisposable {
     }
 
     // Returns the current OAuth idtoken. Refreshes it before returning if expired
-    async getIdToken() {
+    public async getIdToken(): Promise<string> {
 
         const tokenSet = this.configService.tokenSet();
 
@@ -195,7 +195,6 @@ export class OAuthService implements IDisposable {
             this.logger.warn('You need to log in, please run \'zli login --help\'');
             process.exit(1);
         }
-
 
         return this.configService.getAuth();
     }

--- a/src/oauth.service/oauth.service.ts
+++ b/src/oauth.service/oauth.service.ts
@@ -1,4 +1,4 @@
-import { AuthorizationParameters, Client, custom, generators, Issuer, TokenSet, UserinfoResponse } from 'openid-client';
+import { AuthorizationParameters, Client, custom, errors, generators, Issuer, TokenSet, UserinfoResponse } from 'openid-client';
 import open from 'open';
 import { IDisposable } from '../../webshell-common-ts/utility/disposable';
 import { ConfigService } from '../config.service/config.service';
@@ -7,6 +7,7 @@ import { setTimeout } from 'timers';
 import { Logger } from '../../src/logger.service/logger';
 import { loginHtml } from './templates/login';
 import { logoutHtml } from './templates/logout';
+import { cleanExit } from '../../src/handlers/clean-exit.handler';
 
 export class OAuthService implements IDisposable {
     private server: http.Server; // callback listener
@@ -158,6 +159,45 @@ export class OAuthService implements IDisposable {
         const tokenSet = this.configService.tokenSet();
         const userInfo = await client.userinfo(tokenSet);
         return userInfo;
+    }
+
+    // Returns the current OAuth idtoken. Refreshes it before returning if expired
+    async getIdToken() {
+
+        const tokenSet = this.configService.tokenSet();
+
+        // decide if we need to refresh or prompt user for login
+        if(tokenSet)
+        {
+            if(this.configService.tokenSet().expired())
+            {
+                try {
+                    this.logger.debug('Refreshing oauth token');
+
+                    const newTokenSet = await this.refresh();
+                    this.configService.setTokenSet(newTokenSet);
+                    this.logger.debug('Oauth token refreshed');
+                } catch(e) {
+                    if(e instanceof errors.RPError || e instanceof errors.OPError) {
+                        this.logger.error('Stale log in detected');
+                        this.logger.info('You need to log in, please run \'zli login --help\'');
+                        this.configService.logout();
+                        cleanExit(1, this.logger);
+                    } else {
+                        this.logger.error('Unexpected error during oauth refresh');
+                        this.logger.info('Please log in again');
+                        this.configService.logout();
+                        cleanExit(1, this.logger);
+                    }
+                }
+            }
+        } else {
+            this.logger.warn('You need to log in, please run \'zli login --help\'');
+            process.exit(1);
+        }
+
+
+        return this.configService.getAuth();
     }
 
     dispose(): void {

--- a/src/ssm-tunnel/ssm-tunnel.service.ts
+++ b/src/ssm-tunnel/ssm-tunnel.service.ts
@@ -57,7 +57,7 @@ export class SsmTunnelService
             this.ssmTunnelWebsocketService = new SsmTunnelWebsocketService(
                 this.logger,
                 this.keySplittingService,
-                new ZliAuthConfigService(this.configService),
+                new ZliAuthConfigService(this.configService, this.logger),
                 target as SsmTargetInfo
             );
 

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -50,7 +50,7 @@ export class ShellTerminal implements IDisposable
     private createSshShellWebsocketService() {
         return new SshShellWebsocketService(
             this.logger,
-            new ZliAuthConfigService(this.configService),
+            new ZliAuthConfigService(this.configService, this.logger),
             this.connectionId,
             this.inputSubject,
             this.resizeSubject
@@ -62,7 +62,7 @@ export class ShellTerminal implements IDisposable
             new KeySplittingService(this.configService, this.logger),
             ssmTargetInfo,
             this.logger,
-            new ZliAuthConfigService(this.configService),
+            new ZliAuthConfigService(this.configService, this.logger),
             this.connectionId,
             this.inputSubject,
             this.resizeSubject


### PR DESCRIPTION
This adds the ability to check whether the current OAuth id token has expired every time there is an input from the user. If it has, it refreshes before continuing.

It addresses CWC-651

In order to test this:
- Connect to a server with zli that has an agent which supports keysplitting
- Get the current Unix time
- Open with an editor the config file which can be found by `./zli-macos config`
- Find the `expires_at` property
- Copy the current Unix time. Edit that time and add a couple seconds (usually I add 40s). Save the file.
- Type input in the zli-dev. If you want to verify that the token is getting refreshed look for "refresh" in the logs or monitor the value in the config json file