### PR TITLE
(CWC-669) Update openid-client to 4.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "zli",
       "version": "4.14.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -29,7 +28,7 @@
         "mixpanel": "^0.13.0",
         "noble-ed25519": "^1.0.3",
         "open": "^7.3.0",
-        "openid-client": "^4.2.1",
+        "openid-client": "^4.7.2",
         "qrcode": "^1.4.4",
         "rxjs": "^6.6.3",
         "semver": "^7.3.2",
@@ -5969,14 +5968,17 @@
       }
     },
     "node_modules/jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "dependencies": {
         "@panva/asn1.js": "^1.0.0"
       },
       "engines": {
         "node": ">=10.13.0 < 13 || >=13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6952,13 +6954,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.4.2.tgz",
-      "integrity": "sha512-A3003Ucp/4X1kxDWOCABYm14d1f8JBVhc8DJH/3+Rqm8r+QPbIAJ32y1P7aR3bHOuZyrKJ6YiA0DEXKuOQ9cwQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.7.2.tgz",
+      "integrity": "sha512-xHla09UrP2I/GP1pKarAAqeknTMBpKaCW017DxwEaIzgYiA+4d2gyvRR8rTjf1pyTKJ9qfgytb53TeOrVj49uQ==",
       "dependencies": {
         "aggregate-error": "^3.1.0",
         "got": "^11.8.0",
-        "jose": "^2.0.4",
+        "jose": "^2.0.5",
         "lru-cache": "^6.0.0",
         "make-error": "^1.3.6",
         "object-hash": "^2.0.1",
@@ -6966,6 +6968,9 @@
       },
       "engines": {
         "node": "^10.19.0 || >=12.0.0 < 13 || >=13.7.0 < 14 || >= 14.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -14995,9 +15000,9 @@
       }
     },
     "jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }
@@ -15818,13 +15823,13 @@
       }
     },
     "openid-client": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.4.2.tgz",
-      "integrity": "sha512-A3003Ucp/4X1kxDWOCABYm14d1f8JBVhc8DJH/3+Rqm8r+QPbIAJ32y1P7aR3bHOuZyrKJ6YiA0DEXKuOQ9cwQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.7.2.tgz",
+      "integrity": "sha512-xHla09UrP2I/GP1pKarAAqeknTMBpKaCW017DxwEaIzgYiA+4d2gyvRR8rTjf1pyTKJ9qfgytb53TeOrVj49uQ==",
       "requires": {
         "aggregate-error": "^3.1.0",
         "got": "^11.8.0",
-        "jose": "^2.0.4",
+        "jose": "^2.0.5",
         "lru-cache": "^6.0.0",
         "make-error": "^1.3.6",
         "object-hash": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mixpanel": "^0.13.0",
     "noble-ed25519": "^1.0.3",
     "open": "^7.3.0",
-    "openid-client": "^4.2.1",
+    "openid-client": "^4.7.2",
     "qrcode": "^1.4.4",
     "rxjs": "^6.6.3",
     "semver": "^7.3.2",


### PR DESCRIPTION
This updates openid-client depedency jose from 2.04 => 2.05 which contains a security fix for https://github.com/advisories/GHSA-58f5-hfqc-jgch 