### PR TITLE
Close open tunnels on logout [CWC-628]

### DIFF
--- a/src/handlers/logout.handler.ts
+++ b/src/handlers/logout.handler.ts
@@ -7,6 +7,7 @@ export async function logoutHandler(configService: ConfigService, logger: Logger
     // Deletes the auth tokens from the config which will force the
     // user to login again before running another command
     configService.logout();
+    logger.info('Closing any existing SSH Tunnel Connections');
     logger.info('Logout successful');
     await cleanExit(0, logger);
 }

--- a/src/handlers/ssh-proxy.handler.ts
+++ b/src/handlers/ssh-proxy.handler.ts
@@ -46,6 +46,7 @@ export async function sshProxyHandler(configService: ConfigService, logger: Logg
 
     configService.logoutDetected.subscribe(async () => {
         logger.debug('Logged out by another zli instance. Terminating ssh tunnel');
+        process.stderr.write(`\nLogged out by another zli instance. Terminating ssh tunnel...\n`);
         await ssmTunnelService.closeTunnel();
         await cleanExit(0, logger);
     });

--- a/src/handlers/ssh-proxy.handler.ts
+++ b/src/handlers/ssh-proxy.handler.ts
@@ -43,6 +43,12 @@ export async function sshProxyHandler(configService: ConfigService, logger: Logg
             ssmTunnelService.sendData(data);
         });
     }
+
+    configService.logoutDetected.subscribe(async () => {
+        logger.debug('Logged out by another zli instance. Terminating ssh tunnel');
+        await ssmTunnelService.closeTunnel();
+        await cleanExit(0, logger);
+    });
 }
 
 export interface SshTunnelParameters {

--- a/src/ssm-tunnel/ssm-tunnel.service.ts
+++ b/src/ssm-tunnel/ssm-tunnel.service.ts
@@ -81,6 +81,10 @@ export class SsmTunnelService
         this.sendQueue.push(data);
     }
 
+    public async closeTunnel(): Promise<void> {
+        await this.ssmTunnelWebsocketService.closeConnection();
+    }
+
     private async setupEphemeralSshKey(identityFile: string): Promise<void> {
         const bzeroSshKeyPath = this.configService.sshKeyPath();
 


### PR DESCRIPTION
## Description of the change

This adds a logout listener. This way every zli instance is aware when a logout takes place and closes their open tunnels (if any).

In order to test this:
- Type `./zli-macos ssh-proxy-config` to get info on how to easily create an ssh tunnel
-  Create a tunnel to a target
- Open another terminal and from there type `./zli-macos logout`
- You should get logged out from both instances and the tunnel will automatically close

Related PRs:
https://github.com/bastionzero/webshell-common-ts/pull/33

Known UX issue:
As we close the websocket and we break the ssh connection the following output is printed by the ssh:

![Screen Shot 2021-04-28 at 9 10 49 PM](https://user-images.githubusercontent.com/25698483/116557664-53c1b100-a907-11eb-9e44-940965ae90b5.png)



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [X] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-628

## Potential Security Impacts

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [X] Have you tested the code?
- [X] Have you attached any pictures (if relevant)?
