### PR TITLE
Add check to see if input is TTY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zli",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/handlers/connect.handler.ts
+++ b/src/handlers/connect.handler.ts
@@ -134,6 +134,8 @@ export async function connectHandler(
     // ref: https://nodejs.org/api/readline.html#readline_readline_emitkeypressevents_stream_interface
     const readline = require('readline');
     readline.emitKeypressEvents(process.stdin);
-    process.stdin.setRawMode(true);
+    if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true);
+    }
     process.stdin.on('keypress', (_, key) => terminal.writeString(key.sequence));
 }


### PR DESCRIPTION
## Description of the change

We have an issue when we want to test out ZLI with python. We cannot pipe the `stdin` as the python stdin is not TTY. This change just adds a check to ensure the input is TTY before setting the rawMode. 

Ref: https://stackoverflow.com/questions/53049939/node-daemon-wont-start-with-process-stdin-setrawmodetrue

Please see the QA code here: https://github.com/bastionzero/cwc-infra/pull/56

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-45

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
