### PR TITLE
Force MFA setup as needed and some text fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zli",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -120,7 +120,7 @@ export class CliDriver
                             }
                         )
                         .example('login Google', 'Login with Google')
-                        .example('login Google --mfa 123456', 'Login with Microsoft and enter MFA');
+                        .example('login Microsoft --mfa 123456', 'Login with Microsoft and enter MFA');
                 },
                 async (argv) => {
                     await loginHandler(this.configService, this.logger, argv, this.keySplittingService);

--- a/src/http.service/http.service.ts
+++ b/src/http.service/http.service.ts
@@ -1,7 +1,7 @@
 import { IdP, TargetType } from '../types';
 import got, { Got, HTTPError } from 'got/dist/source';
 import { Dictionary } from 'lodash';
-import { ClientSecretResponse, CloseConnectionRequest, CloseSessionRequest, CloseSessionResponse, ConnectionSummary, CreateConnectionRequest, CreateConnectionResponse, CreateSessionRequest, CreateSessionResponse, DownloadFileRequest, DynamicAccessConfigSummary, EnvironmentDetails, GetAutodiscoveryScriptRequest, GetAutodiscoveryScriptResponse, GetTargetPolicyRequest, GetTargetPolicyResponse, ListSessionsResponse, ListSsmTargetsRequest, MfaClearRequest, MfaResetResponse, MfaTokenRequest, MixpanelTokenResponse, SessionDetails, SshTargetSummary, SsmTargetSummary, TargetUser, UploadFileRequest, UploadFileResponse, UserRegisterResponse, UserSummary, Verb } from './http.service.types';
+import { ClientSecretResponse, CloseConnectionRequest, CloseSessionRequest, CloseSessionResponse, ConnectionSummary, CreateConnectionRequest, CreateConnectionResponse, CreateSessionRequest, CreateSessionResponse, DownloadFileRequest, DynamicAccessConfigSummary, EnvironmentDetails, GetAutodiscoveryScriptRequest, GetAutodiscoveryScriptResponse, GetTargetPolicyRequest, GetTargetPolicyResponse, ListSessionsResponse, ListSsmTargetsRequest, MfaClearRequest, MfaResetRequest, MfaResetResponse, MfaTokenRequest, MixpanelTokenResponse, SessionDetails, SshTargetSummary, SsmTargetSummary, TargetUser, UploadFileRequest, UploadFileResponse, UserRegisterResponse, UserSummary, Verb } from './http.service.types';
 import { ConfigService } from '../config.service/config.service';
 import fs, { ReadStream } from 'fs';
 import FormData from 'form-data';
@@ -372,9 +372,13 @@ export class MfaService extends HttpService
         return this.Post('totp', request);
     }
 
-    public ResetSecret(): Promise<MfaResetResponse>
+    public ResetSecret(forceSetup?: boolean): Promise<MfaResetResponse>
     {
-        return this.Post('reset', {});
+        const request: MfaResetRequest = {
+            forceSetup: !!forceSetup
+        };
+
+        return this.Post('reset', request);
     }
 
     public ClearSecret(userId: string): Promise<void>

--- a/src/http.service/http.service.types.ts
+++ b/src/http.service/http.service.types.ts
@@ -177,6 +177,11 @@ export interface MfaClearRequest
     userId: string;
 }
 
+export interface MfaResetRequest
+{
+    forceSetup: boolean;
+}
+
 export interface MfaResetResponse
 {
     mfaSecretUrl: string;


### PR DESCRIPTION
## Description of the change

There are two key changes here:

1. Allowing the user to enter an MFA code after the user has scanned the QR code. This fixes a bug where the user would perpetually be shown the QR code with no way past it within the ZLI.
2. The other change is needed to handle organization-controlled MFA. The use of the `forceSetup` flag in the reset MFA request allows MFA to be set up for a user who doesn't already have it set up, which generally would be the case for new users logging in through the ZLI for the first time (if they are associated with an org that has org-controlled MFA enabled).

I also fixed a couple text bugs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [x] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-701

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [x] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
