### PR TITLE
Remove vpn reference that is no longer relevant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zli",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/http.service/http.service.types.ts
+++ b/src/http.service/http.service.types.ts
@@ -102,7 +102,6 @@ export interface SshTargetSummary {
     port: number;
     authenticationType: AuthenticationType;
     color: string;
-    vpnId?: string;
     environmentId?: string;
 }
 


### PR DESCRIPTION
## Description of the change

Removed SshTargetSummary.vpnId because it is no longer supported.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-715

## Relevant release note information

Release Notes: Removed SshTargetSummary.vpnId because it is no longer supported.

## Potential Security Impacts

Does this PR have any security impact? No
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
