### PR TITLE
Get string used to call zli for processname

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zli",
-  "version": "4.20.0",
+  "version": "4.20.1",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -66,7 +66,8 @@ export class CliDriver
 
     public start()
     {
-        this.processName = process.argv[0];
+        // ref: https://nodejs.org/api/process.html#process_process_argv0
+        this.processName = process.argv0;
 
         yargs(process.argv.slice(2))
             .scriptName('zli')

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -436,9 +436,10 @@ export class CliDriver
             .option('configName', {type: 'string', choices: ['prod', 'stage', 'dev'], default: this.envMap['configName'], hidden: true})
             .option('debug', {type: 'boolean', default: false, describe: 'Flag to show debug logs'})
             .option('silent', {alias: 's', type: 'boolean', default: false, describe: 'Silence all zli messages, only returns command output'})
-            .strict() // if unknown command, show help
+            .strictCommands() // if unknown command, show help
             .demandCommand() // if no command, show help
             .help() // auto gen help message
+            .showHelpOnFail(false)
             .epilog(`Note:
  - <targetString> format: ${targetStringExample}
  - TargetStrings only require targetUser for SSM and Dynamic targets

--- a/src/oauth.service/oauth.service.ts
+++ b/src/oauth.service/oauth.service.ts
@@ -126,7 +126,7 @@ export class OAuthService implements IDisposable {
     public login(callback: (tokenSet: TokenSet) => void, nonce?: string): Promise<void>
     {
         return new Promise<void>(async (resolve, reject) => {
-            setTimeout(() => reject('Log in timeout reached'), 60 * 1000);
+            setTimeout(() => reject(this.logger.error('Login timeout reached')), 60 * 1000);
 
             const client = await this.getClient();
             const code_verifier = generators.codeVerifier();

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -38,7 +38,7 @@ export class ShellTerminal implements IDisposable
             if( isAgentKeysplittingReady(ssmTargetInfo.agentVersion)) {
                 return this.createSsmShellWebsocketService(ssmTargetInfo);
             } else {
-                this.logger.warn(`Agent version ${ssmTargetInfo.agentVersion} not compatible with keysplitting...falling back to non-keysplitting shell`);
+                this.logger.debug(`Agent version ${ssmTargetInfo.agentVersion} not compatible with keysplitting...falling back to non-keysplitting shell`);
                 return this.createSshShellWebsocketService();
             }
         } else {


### PR DESCRIPTION
## Description of the change

Before we were using the process.argv[0] to get the process name, this is actually the resolved process name after symlink matching. Now we use process.argv0 that returns the string used to call thoum by the user. In the case of brew installs, this will now return `zli` and means that all future ssh-proxy-configs will produce consistent paths and not break when you upgrade via brew.

To test:
 - Pull this branch and run `npm run release`
 - Create a symlink in your `/usr/local/bin` directory to your newly built binary (`cd /usr/local/bin ; ln -s <PATH-TO-NEW-BINARY>`
 - Run `zli-macos ssh-proxy-config` (or whatever you are using) 
 - Notice that it now shows `zli-macos` by the `ProxyCommand` entry and not a resolved executable path. ProxyCommand will leverage your system's `$PATH` to resolve the symlink on it's own.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-668

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact? no
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [x] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
