### PR TITLE
Fix connect command to work with dynamic access targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "zli",
-  "version": "4.17.0",
+  "version": "4.20.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.17.0",
+      "version": "4.20.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/signalr": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zli",
-  "version": "4.20.1",
+  "version": "4.20.2",
   "description": "BastionZero cli",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/handlers/attach.handler.ts
+++ b/src/handlers/attach.handler.ts
@@ -28,5 +28,5 @@ export async function attachHandler(
         logger.error(`Connection ${connectionId} is not open`);
         await cleanExit(1, logger);
     }
-    await createAndRunShell(configService, logger, connectionSummary.id, connectionService);
+    await createAndRunShell(configService, logger, connectionSummary);
 }

--- a/src/handlers/attach.handler.ts
+++ b/src/handlers/attach.handler.ts
@@ -28,5 +28,5 @@ export async function attachHandler(
         logger.error(`Connection ${connectionId} is not open`);
         await cleanExit(1, logger);
     }
-    await createAndRunShell(configService, logger, connectionSummary.serverType, connectionSummary.serverId, connectionId);
+    await createAndRunShell(configService, logger, connectionSummary.id, connectionService);
 }

--- a/src/handlers/connect.handler.ts
+++ b/src/handlers/connect.handler.ts
@@ -15,7 +15,8 @@ export async function connectHandler(
     configService: ConfigService,
     logger: Logger,
     mixpanelService: MixpanelService,
-    parsedTarget: ParsedTargetString) {
+    parsedTarget: ParsedTargetString
+) {
 
     if(! parsedTarget) {
         logger.error('No targets matched your targetName/targetId or invalid target string, must follow syntax:');
@@ -70,7 +71,15 @@ export async function connectHandler(
         await cleanExit(1, logger);
     }
 
-    await createAndRunShell(configService, logger, connectionId, connectionService);
+    // Note: For DATs the actual target to connect to will be a dynamically
+    // created ssm target that is provisioned by the DynamicAccessTarget and not
+    // the id of the dynamic access target. The dynamically created ssm target should be
+    // returned in the connectionSummary.targetId for this newly created
+    // connection
+
+    const connectionSummary = await connectionService.GetConnection(connectionId);
+
+    await createAndRunShell(configService, logger, connectionSummary);
 
     mixpanelService.TrackNewConnection(parsedTarget.type);
 }

--- a/src/handlers/connect.handler.ts
+++ b/src/handlers/connect.handler.ts
@@ -70,7 +70,7 @@ export async function connectHandler(
         await cleanExit(1, logger);
     }
 
-    await createAndRunShell(configService, logger, parsedTarget.type, parsedTarget.id, connectionId);
+    await createAndRunShell(configService, logger, connectionId, connectionService);
 
     mixpanelService.TrackNewConnection(parsedTarget.type);
 }

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -1,7 +1,8 @@
 import termsize from 'term-size';
 import { ConfigService } from './config.service/config.service';
 import { cleanExit } from './handlers/clean-exit.handler';
-import { ConnectionService, SessionService } from './http.service/http.service';
+import { SessionService } from './http.service/http.service';
+import { ConnectionSummary } from './http.service/http.service.types';
 import { Logger } from './logger.service/logger';
 import { ShellTerminal } from './terminal/terminal';
 import { SessionState } from './types';
@@ -9,11 +10,10 @@ import { SessionState } from './types';
 export async function createAndRunShell(
     configService: ConfigService,
     logger: Logger,
-    connectionId: string,
-    connectionService: ConnectionService
+    connectionSummary: ConnectionSummary
 ){
     // connect to target and run terminal
-    const terminal = new ShellTerminal(logger, configService, connectionId, connectionService);
+    const terminal = new ShellTerminal(logger, configService, connectionSummary);
     try {
         await terminal.start(termsize());
     } catch (err) {

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -1,20 +1,19 @@
 import termsize from 'term-size';
 import { ConfigService } from './config.service/config.service';
 import { cleanExit } from './handlers/clean-exit.handler';
-import { SessionService } from './http.service/http.service';
+import { ConnectionService, SessionService } from './http.service/http.service';
 import { Logger } from './logger.service/logger';
 import { ShellTerminal } from './terminal/terminal';
-import { SessionState, TargetType } from './types';
+import { SessionState } from './types';
 
 export async function createAndRunShell(
     configService: ConfigService,
     logger: Logger,
-    targetType: TargetType,
-    targetId: string,
-    connectionId: string
+    connectionId: string,
+    connectionService: ConnectionService
 ){
     // connect to target and run terminal
-    const terminal = new ShellTerminal(logger, configService, connectionId, targetType, targetId);
+    const terminal = new ShellTerminal(logger, configService, connectionId, connectionService);
     try {
         await terminal.start(termsize());
     } catch (err) {

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -8,9 +8,9 @@ import { ConfigService } from '../config.service/config.service';
 import { IShellWebsocketService, ShellEvent, ShellEventType, TerminalSize } from '../../webshell-common-ts/shell-websocket.service/shell-websocket.service.types';
 import { ZliAuthConfigService } from '../config.service/zli-auth-config.service';
 import { Logger } from '../logger.service/logger';
-import { ConnectionService, SsmTargetService } from '../http.service/http.service';
+import { SsmTargetService } from '../http.service/http.service';
 import { TargetType } from '../types';
-import { SsmTargetSummary } from '../http.service/http.service.types';
+import { ConnectionSummary, SsmTargetSummary } from '../http.service/http.service.types';
 
 export class ShellTerminal implements IDisposable
 {
@@ -25,14 +25,13 @@ export class ShellTerminal implements IDisposable
     private terminalRunningStream: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
     public terminalRunning: Observable<boolean> = this.terminalRunningStream.asObservable();
 
-    constructor(private logger: Logger, private configService: ConfigService, private connectionId: string, private connectionService: ConnectionService)
+    constructor(private logger: Logger, private configService: ConfigService, private connectionSummary: ConnectionSummary)
     {
     }
 
     private async createShellWebsocketService() : Promise<IShellWebsocketService> {
-        const connectionInfo = await this.connectionService.GetConnection(this.connectionId);
-        const targetType = connectionInfo.serverType;
-        const targetId = connectionInfo.serverId;
+        const targetType = this.connectionSummary.serverType;
+        const targetId = this.connectionSummary.serverId;
 
         if(targetType === TargetType.SSH) {
             return this.createSshShellWebsocketService();
@@ -54,7 +53,7 @@ export class ShellTerminal implements IDisposable
         return new SshShellWebsocketService(
             this.logger,
             new ZliAuthConfigService(this.configService, this.logger),
-            this.connectionId,
+            this.connectionSummary.id,
             this.inputSubject,
             this.resizeSubject
         );
@@ -66,7 +65,7 @@ export class ShellTerminal implements IDisposable
             ssmTargetInfo,
             this.logger,
             new ZliAuthConfigService(this.configService, this.logger),
-            this.connectionId,
+            this.connectionSummary.id,
             this.inputSubject,
             this.resizeSubject
         );


### PR DESCRIPTION
## Description of the change

This fixes a bug where we were not using the ssm target id and instead using the DAT id when sending a request to get ssm target info. The ssm target info is needed in order to determine which agent version the target is running.

This was originally fixed in https://github.com/bastionzero/zli/pull/108 but got reverted with some refactors that happened to the connect handler.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
