### PR TITLE
Update common ts with keysplitting service bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bastionzero/zli",
-  "version": "4.20.4",
+  "version": "4.20.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bastionzero/zli",
-      "version": "4.20.4",
+      "version": "4.20.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@microsoft/signalr": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "4.20.4",
+  "version": "4.20.5",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",
@@ -43,18 +43,18 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@types/async": "^3.2.5",
     "@microsoft/signalr": "^5.0.0",
+    "@types/async": "^3.2.5",
     "@types/chalk": "^2.2.0",
     "@types/crypto-js": "^4.0.1",
     "@types/figlet": "^1.2.1",
     "@types/lodash": "^4.14.165",
     "@types/node": "^14.14.7",
+    "@types/qrcode": "^1.3.5",
     "@types/semver": "^7.3.4",
+    "@types/sshpk": "^1.10.5",
     "@types/term-size": "^2.0.3",
     "@types/yargs": "^15.0.10",
-    "@types/sshpk": "^1.10.5",
-    "@types/qrcode": "^1.3.5",
     "async": "^3.2.0",
     "chalk": "^4.1.0",
     "cli-table3": "^0.6.0",
@@ -72,11 +72,11 @@
     "rxjs": "^6.6.3",
     "semver": "^7.3.2",
     "sha3": "^2.1.4",
+    "sshpk": "^1.16.1",
     "term-size": "^2.2.1",
     "ts-node": "^9.0.0",
     "winston": "^3.3.3",
-    "yargs": "^16.1.1",
-    "sshpk": "^1.16.1"
+    "yargs": "^16.1.1"
   },
   "pkg": {
     "scripts": [],


### PR DESCRIPTION
## Description of the change

See https://github.com/bastionzero/webshell-common-ts/pull/37 for bug fix description

This bug does not currently affect the zli since the keysplitting.service is only ever used by 1 ssm-shell/tunnel websocket service at a time per zli process. However for consistency and future-proofing this updates the submodule and keeps webapp/zli using the same version of webshell-common-ts.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
