### PR TITLE
Refactor Kube Opa Policy and Commands

### DIFF
--- a/bctl-go-daemon/Daemon/daemonWebsocket/daemonWebsocket.go
+++ b/bctl-go-daemon/Daemon/daemonWebsocket/daemonWebsocket.go
@@ -34,7 +34,7 @@ type DaemonWebsocket struct {
 }
 
 // Constructor to create a new Control Websocket Client
-func NewDaemonWebsocketClient(sessionId string, authHeader string, serviceURL string, assumeRole string, assumeCluster string, environmentId string) *DaemonWebsocket {
+func NewDaemonWebsocketClient(sessionId string, authHeader string, serviceURL string, assumeRole string, assumeClusterId string, environmentId string) *DaemonWebsocket {
 	ret := DaemonWebsocket{}
 
 	// Set us to not ready
@@ -48,7 +48,7 @@ func NewDaemonWebsocketClient(sessionId string, authHeader string, serviceURL st
 	params := make(map[string]string)
 	params["session_id"] = sessionId
 	params["assume_role"] = assumeRole
-	params["assume_cluster"] = assumeCluster
+	params["assume_cluster_id"] = assumeClusterId
 	params["environment_id"] = environmentId
 
 	hubEndpoint := "/api/v1/hub/kube"

--- a/bctl-go-daemon/Daemon/main.go
+++ b/bctl-go-daemon/Daemon/main.go
@@ -23,7 +23,7 @@ func main() {
 	// Our expected flags we need to start
 	serviceURLPtr := flag.String("serviceURL", "", "Service URL to use")
 	assumeRolePtr := flag.String("assumeRole", "", "Kube Role to Assume")
-	assumeClusterPtr := flag.String("assumeCluster", "", "Kube Cluster to Connect to")
+	assumeClusterIdPtr := flag.String("assumeClusterId", "", "Kube Cluster Id to Connect to")
 	daemonPortPtr := flag.String("daemonPort", "", "Daemon Port To Use")
 	localhostTokenPtr := flag.String("localhostToken", "", "Localhost Token to Validate Kubectl commands")
 	environmentIdPtr := flag.String("environmentId", "", "Environment Id of cluster we are connecting too")
@@ -33,7 +33,7 @@ func main() {
 	// Parse and TODO: ensure they all exist
 	flag.Parse()
 
-	possibleArgs := []string{*environmentIdPtr, *sessionIdPtr, *authHeaderPtr, *serviceURLPtr, *assumeRolePtr, *assumeClusterPtr, *daemonPortPtr, *localhostTokenPtr, *certPath, *keyPath}
+	possibleArgs := []string{*environmentIdPtr, *sessionIdPtr, *authHeaderPtr, *serviceURLPtr, *assumeRolePtr, *assumeClusterIdPtr, *daemonPortPtr, *localhostTokenPtr, *certPath, *keyPath}
 	for _, flag := range possibleArgs {
 		if flag == "" {
 			log.Printf("Missing flags!")
@@ -43,7 +43,7 @@ func main() {
 
 	// Open a Websocket to Bastion
 	log.Printf("Opening websocket to Bastion: %s", *serviceURLPtr)
-	wsClient := daemonWebsocket.NewDaemonWebsocketClient(*sessionIdPtr, *authHeaderPtr, *serviceURLPtr, *assumeRolePtr, *assumeClusterPtr, *environmentIdPtr)
+	wsClient := daemonWebsocket.NewDaemonWebsocketClient(*sessionIdPtr, *authHeaderPtr, *serviceURLPtr, *assumeRolePtr, *assumeClusterIdPtr, *environmentIdPtr)
 
 	go func() {
 		// Define our http handlers

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -192,75 +192,75 @@ export class CliDriver
                 }
             )
             .command(
-                'addrole <clusterUserName> <clusterName>',
+                'addrole <clusterUserName> <policyName>',
                 'Add a ClusterUser to a Cluster Policy',
                 (yargs) => {
                     return yargs
                         .positional('clusterUserName', {
                             type: 'string',
                         })
-                        .positional('clusterName', {
+                        .positional('policyName', {
                             type: 'string',
                         })
                         .option('force', {
                             type: 'boolean',
                             alias: 'f'
                         })
-                        .example('addrole admin test-cluster', 'Adds the admin RBAC Role to the test-cluster');
+                        .example('addrole admin test-cluster', 'Adds the admin RBAC Role to the test-cluster policy');
                 },
                 async (argv) => {
-                    await addRoleHandler(argv.clusterUserName, argv.clusterName, argv.force, this.clusterTargets, this.configService, this.logger);
+                    await addRoleHandler(argv.clusterUserName, argv.policyName, argv.force, this.clusterTargets, this.configService, this.logger);
                 }
             )
             .command(
-                'removerole <clusterUserName> <clusterName>',
+                'removerole <clusterUserName> <policyName>',
                 'Remove a ClusterUser from Cluster Policy',
                 (yargs) => {
                     return yargs
                         .positional('clusterUserName', {
                             type: 'string',
                         })
-                        .positional('clusterName', {
+                        .positional('policyName', {
                             type: 'string',
                         })
-                        .example('addrole admin test-cluster', 'Adds the admin RBAC Role to the test-cluster');
+                        .example('addrole admin test-cluster', 'Adds the admin RBAC Role to the test-cluster policy');
                 },
                 async (argv) => {
-                    await removeRoleHandler(argv.clusterUserName, argv.clusterName, this.clusterTargets, this.configService, this.logger);
+                    await removeRoleHandler(argv.clusterUserName, argv.policyName, this.clusterTargets, this.configService, this.logger);
                 }
             )
             .command(
-                'adduser <idpEmail> <clusterName>',
+                'adduser <idpEmail> <policyName>',
                 'Add a IDP User to a Cluster Policy',
                 (yargs) => {
                     return yargs
                         .positional('idpEmail', {
                             type: 'string',
                         })
-                        .positional('clusterName', {
+                        .positional('policyName', {
                             type: 'string',
                         })
                         .example('adduser test@test.com test-cluster', 'Adds the test@test.com IDP user test-cluster policy');
                 },
                 async (argv) => {
-                    await addUserHandler(argv.idpEmail, argv.clusterName, this.clusterTargets, this.configService, this.logger);
+                    await addUserHandler(argv.idpEmail, argv.policyName, this.clusterTargets, this.configService, this.logger);
                 }
             )
             .command(
-                'removeuser <idpEmail> <clusterName>',
+                'removeuser <idpEmail> <policyName>',
                 'Remove a IDP User to a Cluster Policy',
                 (yargs) => {
                     return yargs
                         .positional('idpEmail', {
                             type: 'string',
                         })
-                        .positional('clusterName', {
+                        .positional('policyName', {
                             type: 'string',
                         })
                         .example('removeuser test@test.com test-cluster', 'Removes the test@test.com IDP user test-cluster policy');
                 },
                 async (argv) => {
-                    await removeUserHandler(argv.idpEmail, argv.clusterName, this.clusterTargets, this.configService, this.logger);
+                    await removeUserHandler(argv.idpEmail, argv.policyName, this.clusterTargets, this.configService, this.logger);
                 }
             )
             .command(
@@ -268,6 +268,9 @@ export class CliDriver
                 'Get detailed information about a certain cluster',
                 (yargs) => {
                     return yargs
+                        .positional('clusterName', {
+                            type: 'string',
+                        })
                         .example('status test-cluster', '');
                 },
                 async (argv) => {
@@ -637,6 +640,10 @@ export class CliDriver
                             alias: 'o',
                             default: null
                         })
+                        .option('environmentId', {
+                            type: 'string',
+                            default: null
+                        })
                         .example('generate kubeYaml testcluster', '')
                         .example('generate kubeConfig', '')
                         .example('generate kubeYaml --labels testkey:testvalue', '');
@@ -645,7 +652,7 @@ export class CliDriver
                     if (argv.typeOfConfig == 'kubeConfig') {
                         await generateKubeconfigHandler(argv, this.configService, this.logger);
                     } else if (argv.typeOfConfig == 'kubeYaml') {
-                        await generateKubeYamlHandler(argv, this.configService, this.logger);
+                        await generateKubeYamlHandler(argv, this.envs, this.configService, this.logger);
                     }
                 }
             )

--- a/src/handlers/add-role.handler.ts
+++ b/src/handlers/add-role.handler.ts
@@ -7,32 +7,32 @@ import { ClusterSummary, KubeClusterStatus } from "../types";
 import { cleanExit } from './clean-exit.handler';
 
 
-export async function addRoleHandler(clusterUserName: string, clusterName: string, force: boolean, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
+export async function addRoleHandler(clusterUserName: string, policyName: string, force: boolean, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
     // First get the existing policy
     const policyService = new PolicyService(configService, logger);
     const policies = await policyService.ListAllPolicies();
 
-    // Check if this is a valid cluster name
-    var validUser = false;
-    for (var clusterInfo of await clusterTargets) {
-        if (clusterInfo.name == clusterName) {
-            for (var possibleRole of clusterInfo.validUsers) {
-                if (possibleRole == clusterUserName) {
-                    validUser = true;
-                }
-            }
-        }
-    }
+    // Check if this is a valid cluster name TODO: Do we still do this?
+    // var validUser = false;
+    // for (var clusterInfo of await clusterTargets) {
+    //     if (clusterInfo.name == clusterName) {
+    //         for (var possibleRole of clusterInfo.validUsers) {
+    //             if (possibleRole == clusterUserName) {
+    //                 validUser = true;
+    //             }
+    //         }
+    //     }
+    // }
 
     // If this is not a valid role, and they have not passed the force flag, exit
-    if (validUser == false && force != true) {
-        logger.error(`The role chosen: ${clusterUserName} is not a valid role on the cluster ${clusterName}. If this is a mistake, please use the -f flag. Run zli describe <custerName> to see all valid cluster roles.`)
-        await cleanExit(1, logger);
-    }
+    // if (validUser == false && force != true) {
+    //     logger.error(`The role chosen: ${clusterUserName} is not a valid role on the cluster ${clusterName}. If this is a mistake, please use the -f flag. Run zli describe <custerName> to see all valid cluster roles.`)
+    //     await cleanExit(1, logger);
+    // }
 
     // Loop till we find the one we are looking for
     for (const policy of policies) {
-        if (policy.name == clusterName) {
+        if (policy.name == policyName) {
             // Then add the role to the policy
             var clusterUserToAdd: KubernetesPolicyClusterUsers = {
                 name: clusterUserName
@@ -42,13 +42,13 @@ export async function addRoleHandler(clusterUserName: string, clusterName: strin
             // And finally update the policy
             await policyService.UpdateKubePolicy(policy);
 
-            logger.info(`Added ${clusterUserName} to ${clusterName} policy!`)
+            logger.info(`Added ${clusterUserName} to ${policyName} policy!`)
             await cleanExit(0, logger);
         }
     }
 
     // Log an error
-    logger.error(`Unable to find the policy for cluster: ${clusterName}`);
+    logger.error(`Unable to find the policy: ${policyName}`);
     await cleanExit(1, logger);
 }
 

--- a/src/handlers/add-role.handler.ts
+++ b/src/handlers/add-role.handler.ts
@@ -12,24 +12,6 @@ export async function addRoleHandler(clusterUserName: string, policyName: string
     const policyService = new PolicyService(configService, logger);
     const policies = await policyService.ListAllPolicies();
 
-    // Check if this is a valid cluster name TODO: Do we still do this?
-    // var validUser = false;
-    // for (var clusterInfo of await clusterTargets) {
-    //     if (clusterInfo.name == clusterName) {
-    //         for (var possibleRole of clusterInfo.validUsers) {
-    //             if (possibleRole == clusterUserName) {
-    //                 validUser = true;
-    //             }
-    //         }
-    //     }
-    // }
-
-    // If this is not a valid role, and they have not passed the force flag, exit
-    // if (validUser == false && force != true) {
-    //     logger.error(`The role chosen: ${clusterUserName} is not a valid role on the cluster ${clusterName}. If this is a mistake, please use the -f flag. Run zli describe <custerName> to see all valid cluster roles.`)
-    //     await cleanExit(1, logger);
-    // }
-
     // Loop till we find the one we are looking for
     for (const policy of policies) {
         if (policy.name == policyName) {

--- a/src/handlers/add-user.handler.ts
+++ b/src/handlers/add-user.handler.ts
@@ -6,7 +6,7 @@ import { ClusterSummary } from '../types';
 import { cleanExit } from './clean-exit.handler';
 
 
-export async function addUserHandler(userEmail: string, clusterName: string, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
+export async function addUserHandler(userEmail: string, policyName: string, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
     // First ensure we can lookup the user
     const kubeService = new KubeService(configService, logger);
 
@@ -25,7 +25,7 @@ export async function addUserHandler(userEmail: string, clusterName: string, clu
 
     // Loop till we find the one we are looking for
     for (const policy of policies) {
-        if (policy.name == clusterName) {
+        if (policy.name == policyName) {
             // Then add the user to the policy
             const subjectToAdd: Subject = {
                 id: userInfo.id,
@@ -36,13 +36,13 @@ export async function addUserHandler(userEmail: string, clusterName: string, clu
             // And finally update the policy
             await policyService.UpdateKubePolicy(policy);
 
-            logger.info(`Added ${userEmail} to ${clusterName} policy!`);
+            logger.info(`Added ${userEmail} to ${policyName} policy!`);
             await cleanExit(0, logger);
         }
     }
 
     // Log an error
-    logger.error(`Unable to find the policy for cluster: ${clusterName}`);
+    logger.error(`Unable to find the policy for cluster: ${policyName}`);
     await cleanExit(1, logger);
 }
 

--- a/src/handlers/describe.handler.ts
+++ b/src/handlers/describe.handler.ts
@@ -35,17 +35,18 @@ export async function describeHandler(
             break;
         }
     }
-    // Now make a query to see all the policy information
-    const policyService = new PolicyQueryService(configService, logger);
-    const clusterPolicyInfo = await policyService.DescribeKubeProxy(clusterName);
 
-    // Build our clusteruser string 
-    var clusterUserString = '';
-    for (var clusterUser of clusterPolicyInfo.clusterUsers) {
-        clusterUserString += clusterUser.name + ',';
+    // Now make a query to see all policies associated with this cluster
+    const policyService = new PolicyQueryService(configService, logger);
+    const clusterPolicyInfo = await policyService.GetAllPoliciesForClusterId(clusterSummary.id);
+
+    // Build our policies string 
+    var policiesString = '';
+    for (var policy of clusterPolicyInfo.policies) {
+        policiesString += policy.name + ',';
     }
-    if (clusterPolicyInfo.clusterUsers.length != 0) {
-        clusterUserString = clusterUserString.substring(0, clusterUserString.length - 1); // remove trailing ,
+    if (clusterPolicyInfo.policies.length != 0) {
+        policiesString = policiesString.substring(0, policiesString.length - 1); // remove trailing ,
     }
 
     // Build our validUsers string
@@ -58,6 +59,6 @@ export async function describeHandler(
     // Now we can print all the information we know
     logger.info(`Cluster information for: ${clusterName}`);
     logger.info(`    - Environment Name: ${environment.name}`)
-    logger.info(`    - Cluster Users Attached To Policy: ${clusterUserString}`)
+    logger.info(`    - Policies using this cluster: ${policiesString}`)
     logger.info(`    - Valid Cluster Users: ${validUserString}`)
 }

--- a/src/handlers/remove-role.handler.ts
+++ b/src/handlers/remove-role.handler.ts
@@ -7,17 +7,17 @@ import { ClusterSummary, KubeClusterStatus } from "../types";
 import { cleanExit } from './clean-exit.handler';
 
 
-export async function removeRoleHandler(clusterUserName: string, clusterName: string, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
+export async function removeRoleHandler(clusterUserName: string, policyName: string, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
     // First get the existing policy
     const policyService = new PolicyService(configService, logger);
     const policies = await policyService.ListAllPolicies();
 
     // Loop till we find the one we are looking for
     for (const policy of policies) {
-        if (policy.name == clusterName) {
+        if (policy.name == policyName) {
             // Now check if the role exists
             if (policy.context.clusterUsers[clusterUserName] === undefined) {
-                logger.error(`No role ${clusterUserName} exist for policy for cluster: ${clusterName}`);
+                logger.error(`No role ${clusterUserName} exist for policy: ${policyName}`);
                 await cleanExit(1, logger);
             }
             // Then remove the role from the policy if it exists
@@ -26,13 +26,13 @@ export async function removeRoleHandler(clusterUserName: string, clusterName: st
             // And finally update the policy
             await policyService.UpdateKubePolicy(policy);
 
-            logger.info(`Removed ${clusterUserName} from ${clusterName} policy!`)
+            logger.info(`Removed ${clusterUserName} from ${policyName} policy!`)
             await cleanExit(0, logger);
         }
     }
 
     // Log an error
-    logger.error(`Unable to find the policy for cluster: ${clusterName}`);
+    logger.error(`Unable to find the policy: ${policyName}`);
     await cleanExit(1, logger);
 }
 

--- a/src/handlers/remove-user.handler.ts
+++ b/src/handlers/remove-user.handler.ts
@@ -5,7 +5,7 @@ import { ClusterSummary } from '../types';
 import { cleanExit } from './clean-exit.handler';
 
 
-export async function removeUserHandler(userEmail: string, clusterName: string, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
+export async function removeUserHandler(userEmail: string, policyName: string, clusterTargets: Promise<ClusterSummary[]>, configService: ConfigService, logger: Logger) {
     // First ensure we can lookup the user
     const kubeService = new KubeService(configService, logger);
     const userInfo = await kubeService.GetUserInfoFromEmail(userEmail);
@@ -22,7 +22,7 @@ export async function removeUserHandler(userEmail: string, clusterName: string, 
 
     // Loop till we find the one we are looking for
     for (const policy of policies) {
-        if (policy.name == clusterName) {
+        if (policy.name == policyName) {
             // TODO: This can be done better then looping
             // Then remove the user from the policy
             const newSubjects = [];
@@ -36,13 +36,13 @@ export async function removeUserHandler(userEmail: string, clusterName: string, 
             // And finally update the policy
             await policyService.UpdateKubePolicy(policy);
 
-            logger.info(`Removed ${userEmail} from ${clusterName} policy!`);
+            logger.info(`Removed ${userEmail} from ${policyName} policy!`);
             await cleanExit(0, logger);
         }
     }
 
     // Log an error
-    logger.error(`Unable to find the policy for cluster: ${clusterName}`);
+    logger.error(`Unable to find the policy: ${policyName}`);
     await cleanExit(1, logger);
 }
 

--- a/src/handlers/start-kube-daemon.handler.ts
+++ b/src/handlers/start-kube-daemon.handler.ts
@@ -42,7 +42,7 @@ export async function startKubeDaemonHandler(argv: any, assumeUser: string, assu
     }
 
     // Build our args and cwd
-    let args = [`-sessionId=${configService.sessionId()}`, `-assumeRole=${assumeUser}`, `-assumeCluster=${assumeCluster}`, `-daemonPort=${kubeConfig['localPort']}`, `-serviceURL=${configService.serviceUrl().slice(0, -1).replace('https://', '')}`, `-authHeader="${configService.getAuthHeader()}"`, `-localhostToken="${kubeConfig['token']}"`, `-environmentId="${clusterTarget.environmentId}"`, `-certPath="${kubeConfig['certPath']}"`, `-keyPath="${kubeConfig['keyPath']}"`];
+    let args = [`-sessionId=${configService.sessionId()}`, `-assumeRole=${assumeUser}`, `-assumeClusterId=${clusterTarget.id}`, `-daemonPort=${kubeConfig['localPort']}`, `-serviceURL=${configService.serviceUrl().slice(0, -1).replace('https://', '')}`, `-authHeader="${configService.getAuthHeader()}"`, `-localhostToken="${kubeConfig['token']}"`, `-environmentId="${clusterTarget.environmentId}"`, `-certPath="${kubeConfig['certPath']}"`, `-keyPath="${kubeConfig['keyPath']}"`];
     let cwd = process.cwd();
 
 

--- a/src/http.service/http.service.ts
+++ b/src/http.service/http.service.ts
@@ -1,7 +1,7 @@
 import { IdP, TargetType } from '../types';
 import got, { Got, HTTPError } from 'got/dist/source';
 import { Dictionary } from 'lodash';
-import { ClientSecretResponse, CloseConnectionRequest, CloseSessionRequest, CloseSessionResponse, ConnectionSummary, CreateConnectionRequest, CreateConnectionResponse, CreateSessionRequest, CreateSessionResponse, DownloadFileRequest, DynamicAccessConfigSummary, EnvironmentDetails, GetAutodiscoveryScriptRequest, GetAutodiscoveryScriptResponse, GetTargetPolicyRequest, GetTargetPolicyResponse, ListSessionsResponse, ListSsmTargetsRequest, MfaClearRequest, MfaResetRequest, MfaResetResponse, MfaTokenRequest, MixpanelTokenResponse, SessionDetails, SshTargetSummary, SsmTargetSummary, TargetUser, UploadFileRequest, UploadFileResponse, UserRegisterResponse, UserSummary, Verb, GetKubeUnregisteredAgentYamlResponse, GetKubeUnregisteredAgentYamlRequest, ClusterSummary, KubeProxyResponse, KubeProxyRequest, KubernetesPolicySummary, UpdateKubePolicyRequest, GetUserInfoResponse, GetUserInfoRequest, KubeProxyDescribeRequest, KubeProxyDescribeResponse} from './http.service.types';
+import { ClientSecretResponse, CloseConnectionRequest, CloseSessionRequest, CloseSessionResponse, ConnectionSummary, CreateConnectionRequest, CreateConnectionResponse, CreateSessionRequest, CreateSessionResponse, DownloadFileRequest, DynamicAccessConfigSummary, EnvironmentDetails, GetAutodiscoveryScriptRequest, GetAutodiscoveryScriptResponse, GetTargetPolicyRequest, GetTargetPolicyResponse, ListSessionsResponse, ListSsmTargetsRequest, MfaClearRequest, MfaResetRequest, MfaResetResponse, MfaTokenRequest, MixpanelTokenResponse, SessionDetails, SshTargetSummary, SsmTargetSummary, TargetUser, UploadFileRequest, UploadFileResponse, UserRegisterResponse, UserSummary, Verb, GetKubeUnregisteredAgentYamlResponse, GetKubeUnregisteredAgentYamlRequest, ClusterSummary, KubeProxyResponse, KubeProxyRequest, KubernetesPolicySummary, UpdateKubePolicyRequest, GetUserInfoResponse, GetUserInfoRequest, GetAllPoliciesForClusterIdRequest, GetAllPoliciesForClusterIdResponse} from './http.service.types';
 import { ConfigService } from '../config.service/config.service';
 import fs, { ReadStream } from 'fs';
 import FormData from 'form-data';
@@ -470,15 +470,15 @@ export class PolicyQueryService extends HttpService
         return this.FormPost('kube-proxy', request);
     }
 
-    public DescribeKubeProxy(
-        clusterName: string,
-    ): Promise<KubeProxyDescribeResponse>
+    public GetAllPoliciesForClusterId(
+        clusterId: string,
+    ): Promise<GetAllPoliciesForClusterIdResponse>
     {
-        const request: KubeProxyDescribeRequest = {
-            clusterName: clusterName,
+        const request: GetAllPoliciesForClusterIdRequest = {
+            clusterId: clusterId,
         };
 
-        return this.FormPost('describe-kube-proxy', request);
+        return this.FormPost('get-kube-policies', request);
     }
 }
 
@@ -517,13 +517,15 @@ export class KubeService extends HttpService
     public getKubeUnregisteredAgentYaml(
         clusterName: string,
         labels: string,
-        namespace: string
+        namespace: string,
+        environmentId: string,
     ): Promise<GetKubeUnregisteredAgentYamlResponse>
     {
         const request: GetKubeUnregisteredAgentYamlRequest = {
             clusterName: clusterName,
             labels: labels,
             namespace: namespace,
+            environmentId: environmentId,
         };
         return this.FormPost('get-agent-yaml', request);
     }

--- a/src/http.service/http.service.types.ts
+++ b/src/http.service/http.service.types.ts
@@ -273,6 +273,7 @@ export interface GetKubeUnregisteredAgentYamlRequest {
     clusterName: string;
     labels: string;
     namespace: string;
+    environmentId: string;
 }
 export interface GetKubeUnregisteredAgentYamlResponse {
     yaml: string;
@@ -287,16 +288,18 @@ export interface KubeProxyResponse {
     allowed: boolean;
 }
 
-export interface KubeProxyDescribeRequest {
-    clusterName: string;
+export interface GetAllPoliciesForClusterIdRequest {
+    clusterId: string;
 }
-export interface KubeProxyDescribeResponse {
-    clusterUsers: ClusterUser[]
+export interface GetAllPoliciesForClusterIdResponse {
+    policies: PolicySummary[]
 }
 
-interface ClusterUser {
+interface PolicySummary {
     name: string;
+    id: string;
 }
+
 export interface KubernetesPolicySummary {
     id: string;
     name: string;


### PR DESCRIPTION
## Description of the change

Now we do not assume a 1:1 mapping between opa policy and clusters. So `addrole`/ `adduser` now interact directly with the policy. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-998

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
