### PR TITLE
Create new command generate-bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -37,6 +37,7 @@ import { bctlHandler } from './handlers/bctl.handler';
 import { listPoliciesHandler } from './handlers/policy/list-policies.handler';
 import { listTargetUsersHandler } from './handlers/target-user/list-target-users.handler';
 import { fetchGroupsHandler } from './handlers/group/fetch-groups.handler';
+import { generateBashHandler } from './handlers/generate-bash/generate-bash.handler';
 
 // 3rd Party Modules
 import { Dictionary, includes } from 'lodash';
@@ -60,6 +61,7 @@ import { targetUserCmdBuilder } from './handlers/target-user/target-user.command
 import { sshProxyCmdBuilder } from './handlers/ssh-proxy/ssh-proxy.command-builder';
 import { autoDiscoveryScriptCommandBuilder } from './handlers/autodiscovery-script/autodiscovery-script.command-builder';
 import { generateKubeCmdBuilder } from './handlers/generate-kube/generate-kube.command-builder';
+import { generateBashCmdBuilder } from './handlers/generate-bash/generate-bash.command-builder';
 import { TargetSummary, TargetType, TargetStatus } from './services/common.types';
 import { EnvironmentDetails } from './services/environment/environment.types';
 import { MixpanelService } from './services/mixpanel/mixpanel.service';
@@ -103,7 +105,8 @@ export class CliDriver
         'autodiscovery-script',
         'generate',
         'policy',
-        'group'
+        'group',
+        'generate-bash'
     ];
 
     private mixpanelCommands: string[] = [
@@ -128,7 +131,8 @@ export class CliDriver
         'autodiscovery-script',
         'generate',
         'policy',
-        'group'
+        'group',
+        'generate-bash'
     ];
 
     private fetchCommands: string[] = [
@@ -151,7 +155,8 @@ export class CliDriver
         'autodiscovery-script',
         'generate',
         'policy',
-        'group'
+        'group',
+        'generate-bash'
     ];
 
     private adminOnlyCommands: string[] = [
@@ -455,8 +460,18 @@ export class CliDriver
                 }
             )
             .command(
+                'generate-bash',
+                'Returns a bash script to autodiscover a target.',
+                (yargs) => {
+                   return generateBashCmdBuilder(yargs) ;
+                },
+                async (argv) => {
+                    await generateBashHandler(argv, this.logger, this.configService, this.envs);
+                },
+            )
+            .command(
                 'autodiscovery-script <operatingSystem> <targetName> <environmentName> [agentVersion]',
-                'Returns autodiscovery script',
+                'Returns autodiscovery script. [deprecated. Use generate-bash instead]',
                 (yargs) => {
                     return autoDiscoveryScriptCommandBuilder(yargs);
                 },

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -463,7 +463,7 @@ export class CliDriver
                 'generate-bash',
                 'Returns a bash script to autodiscover a target.',
                 (yargs) => {
-                   return generateBashCmdBuilder(yargs) ;
+                   return generateBashCmdBuilder(process.argv, yargs) ;
                 },
                 async (argv) => {
                     await generateBashHandler(argv, this.logger, this.configService, this.envs);

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -463,7 +463,7 @@ export class CliDriver
                 'generate-bash',
                 'Returns a bash script to autodiscover a target.',
                 (yargs) => {
-                   return generateBashCmdBuilder(process.argv, yargs) ;
+                    return generateBashCmdBuilder(process.argv, yargs) ;
                 },
                 async (argv) => {
                     await generateBashHandler(argv, this.logger, this.configService, this.envs);

--- a/src/handlers/autodiscovery-script/autodiscovery-script-handler.ts
+++ b/src/handlers/autodiscovery-script/autodiscovery-script-handler.ts
@@ -16,6 +16,9 @@ export async function autoDiscoveryScriptHandler(
     configService: ConfigService,
     environments: Promise<EnvironmentDetails[]>
 ) {
+    // Print deprecation warning
+    logger.warn('Warning: zli autodiscovery-script is no longer supported and will be removed in a future release. Please use zli generate-bash instead.');
+
     const environmentNameArg = argv.environmentName;
     const outputFileArg = argv.outputFile;
     const agentVersionArg = argv.agentVersion;
@@ -28,7 +31,7 @@ export async function autoDiscoveryScriptHandler(
     }
 
     const autodiscoveryScriptService = new AutoDiscoveryScriptService(configService, logger);
-    const autodiscoveryScriptResponse = await autodiscoveryScriptService.getAutodiscoveryScript(argv.operatingSystem, argv.targetName, environment.id, agentVersionArg);
+    const autodiscoveryScriptResponse = await autodiscoveryScriptService.getAutodiscoveryScript(argv.operatingSystem, `TARGET_NAME=\"${argv.targetName}\"`, environment.id, agentVersionArg);
 
     if(outputFileArg) {
         await util.promisify(fs.writeFile)(outputFileArg, autodiscoveryScriptResponse.autodiscoveryScript);

--- a/src/handlers/generate-bash/generate-bash.command-builder.test.ts
+++ b/src/handlers/generate-bash/generate-bash.command-builder.test.ts
@@ -1,0 +1,40 @@
+import yargs from "yargs";
+import { generateBashCmdBuilder } from "./generate-bash.command-builder";
+
+// Tests that code in .check() in generateBashCmdBuilder() does not mess up
+// mutual exclusion check on --targetName and --targetNameScheme flags
+test.each([
+    [["--targetName", "foo", "--targetNameScheme", "time"]],
+    [["--targetName", "foo", "       --targetNameScheme", "time"]],
+    [["--targetName", "foo", "--targetNameScheme=time"]],
+    [["--targetName", "foo", "       --targetNameScheme=time"]],
+])('check mutually exclusive error is thrown with processArgs: %s', (processArgs) => {
+    // Simulate passing in arguments for yargs and store validation error
+    let validationErr: Error;
+    yargs.command('generate-bash', '', (yargs) => generateBashCmdBuilder(processArgs, yargs), () => { })
+        .parse(['generate-bash', ...processArgs], {}, (err) => {
+            validationErr = err;
+        });
+
+    // Assert that mutual exclusion error is thrown
+    expect(validationErr).not.toBeNull();
+    expect(validationErr.message).toEqual('Arguments targetNameScheme and targetName are mutually exclusive');
+});
+
+// Tests that code in .check() in generateBashCmdBuilder() correctly permits the
+// --targetName flag to be passed by itself without any validation errors (e.g.
+// mutual exclusion error)
+test.each([
+    [["--targetName", "foo"]],
+    [["-n", "foo"]],
+])('check no validation error is thrown with processArgs: %s', (processArgs) => {
+    // Simulate passing in arguments for yargs and store validation error
+    let validationErr: Error;
+    yargs.command('generate-bash', '', (yargs) => generateBashCmdBuilder(processArgs, yargs), () => { })
+        .parse(['generate-bash', ...processArgs], {}, (err) => {
+            validationErr = err;
+        });
+
+    // Assert that no validation error is thrown
+    expect(validationErr).toBeNull();
+});

--- a/src/handlers/generate-bash/generate-bash.command-builder.test.ts
+++ b/src/handlers/generate-bash/generate-bash.command-builder.test.ts
@@ -1,13 +1,13 @@
-import yargs from "yargs";
-import { generateBashCmdBuilder } from "./generate-bash.command-builder";
+import yargs from 'yargs';
+import { generateBashCmdBuilder } from './generate-bash.command-builder';
 
 // Tests that code in .check() in generateBashCmdBuilder() does not mess up
 // mutual exclusion check on --targetName and --targetNameScheme flags
 test.each([
-    [["--targetName", "foo", "--targetNameScheme", "time"]],
-    [["--targetName", "foo", "       --targetNameScheme", "time"]],
-    [["--targetName", "foo", "--targetNameScheme=time"]],
-    [["--targetName", "foo", "       --targetNameScheme=time"]],
+    [['--targetName', 'foo', '--targetNameScheme', 'time']],
+    [['--targetName', 'foo', '       --targetNameScheme', 'time']],
+    [['--targetName', 'foo', '--targetNameScheme=time']],
+    [['--targetName', 'foo', '       --targetNameScheme=time']],
 ])('check mutually exclusive error is thrown with processArgs: %s', (processArgs) => {
     // Simulate passing in arguments for yargs and store validation error
     let validationErr: Error;
@@ -25,8 +25,8 @@ test.each([
 // --targetName flag to be passed by itself without any validation errors (e.g.
 // mutual exclusion error)
 test.each([
-    [["--targetName", "foo"]],
-    [["-n", "foo"]],
+    [['--targetName', 'foo']],
+    [['-n', 'foo']],
 ])('check no validation error is thrown with processArgs: %s', (processArgs) => {
     // Simulate passing in arguments for yargs and store validation error
     let validationErr: Error;

--- a/src/handlers/generate-bash/generate-bash.command-builder.ts
+++ b/src/handlers/generate-bash/generate-bash.command-builder.ts
@@ -10,7 +10,7 @@ export type generateBashArgs = { environment: string } &
 { targetName: string } &
 { outputFile: string }
 
-export function generateBashCmdBuilder(yargs: yargs.Argv<{}>): yargs.Argv<generateBashArgs> {
+export function generateBashCmdBuilder(processArgs : string[], yargs: yargs.Argv<{}>): yargs.Argv<generateBashArgs> {
     return yargs
         .option(
             'environment',
@@ -72,7 +72,7 @@ export function generateBashCmdBuilder(yargs: yargs.Argv<{}>): yargs.Argv<genera
             }
         )
         .check(function (argv) {
-            if (process.argv.find(arg => new RegExp('targetNameScheme').test(arg)) === undefined && argv.targetName !== undefined) {
+            if (processArgs.find(arg => new RegExp('targetNameScheme').test(arg)) === undefined && argv.targetName !== undefined) {
                 // If user did not pass --targetNameScheme but
                 // did pass something for the targetName flag
 

--- a/src/handlers/generate-bash/generate-bash.command-builder.ts
+++ b/src/handlers/generate-bash/generate-bash.command-builder.ts
@@ -1,0 +1,98 @@
+import yargs from 'yargs';
+
+const targetNameSchemes = ["do", "aws", "time", "hostname"] as const;
+export type TargetNameScheme = typeof targetNameSchemes[number];
+
+export type generateBashArgs = { environment: string } &
+{ targetNameScheme: TargetNameScheme } &
+{ agentVersion: string } &
+{ os: string } &
+{ targetName: string } &
+{ outputFile: string }
+
+export function generateBashCmdBuilder(yargs: yargs.Argv<{}>): yargs.Argv<generateBashArgs> {
+    return yargs
+        .option(
+            'environment',
+            {
+                type: 'string',
+                demandOption: false,
+                alias: 'e',
+                default: 'Default',
+                describe: 'Specifies the target\'s environment',
+            }
+        )
+        .option(
+            'targetNameScheme',
+            {
+                demandOption: false,
+                choices: targetNameSchemes,
+                default: 'hostname' as TargetNameScheme,
+                conflicts: 'targetName',
+                describe: 'Configures the target name from a specific source. Flag cannot be used with --targetName',
+            }
+        )
+        .option(
+            'agentVersion',
+            {
+                type: 'string',
+                demandOption: false,
+                default: 'latest',
+                describe: 'Use a specific version of the agent',
+            }
+        )
+        .option(
+            'os',
+            {
+                type: 'string',
+                demandOption: false,
+                choices: ['centos', 'ubuntu', 'universal'],
+                default: 'universal',
+                describe: 'Assume a specific operating system',
+            }
+        )
+        .option(
+            'targetName',
+            {
+                type: 'string',
+                demandOption: false,
+                conflicts: 'targetNameScheme',
+                alias: 'n',
+                default: undefined,
+                describe: 'Set the target name explicitly. Flag cannot be used with --targetNameScheme'
+            }
+        )
+        .option(
+            'outputFile',
+            {
+                type: 'string',
+                demandOption: false,
+                alias: 'o',
+                describe: 'Write the script to a file'
+            }
+        )
+        .check(function (argv) {
+            if (process.argv.find(arg => new RegExp('targetNameScheme').test(arg)) === undefined && argv.targetName !== undefined) {
+                // If user did not pass --targetNameScheme but
+                // did pass something for the targetName flag
+
+                // We must look at process.argv, and not
+                // yargs.argv, because yargs.argv does not have
+                // a way to check if user actually passed in
+                // something for a flag that has a default !=
+                // undefined.
+
+                // We must override the default of "hostname"
+                // and set it to undefined so that the
+                // targetName flag can be passed in by itself
+                // and not run into "mutually exclusive"
+                // problem with defaults. See:
+                // https://github.com/yargs/yargs/issues/929
+                argv.targetNameScheme = undefined;
+            }
+            return true;
+        })
+        .example('generate-bash --targetName my-target -e my-custom-env', '')
+        .example('generate-bash --targetNameScheme time', '')
+        .example('generate-bash -o script.sh', 'Writes the script to a file "script.sh" in the current directory');
+}

--- a/src/handlers/generate-bash/generate-bash.command-builder.ts
+++ b/src/handlers/generate-bash/generate-bash.command-builder.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs';
 
-const targetNameSchemes = ["do", "aws", "time", "hostname"] as const;
+const targetNameSchemes = ['do', 'aws', 'time', 'hostname'] as const;
 export type TargetNameScheme = typeof targetNameSchemes[number];
 
 export type generateBashArgs = { environment: string } &

--- a/src/handlers/generate-bash/generate-bash.handler.ts
+++ b/src/handlers/generate-bash/generate-bash.handler.ts
@@ -1,0 +1,61 @@
+import util from 'util';
+import fs from 'fs';
+import { Logger } from '../../services/logger/logger.service';
+import { ConfigService } from '../../services/config/config.service';
+import { EnvironmentDetails } from '../../services/environment/environment.types';
+import { AutoDiscoveryScriptService } from '../../services/auto-discovery-script/auto-discovery-script.service';
+import { cleanExit } from '../clean-exit.handler';
+import yargs from 'yargs';
+import { generateBashArgs } from './generate-bash.command-builder';
+
+export async function generateBashHandler(
+    argv: yargs.Arguments<generateBashArgs>,
+    logger: Logger,
+    configService: ConfigService,
+    environments: Promise<EnvironmentDetails[]>
+) {
+    let targetNameScript: string = ""
+    if (argv.targetName === undefined) {
+        switch (argv.targetNameScheme) {
+            case 'do':
+                targetNameScript = "TARGET_NAME=$(curl http://169.254.169.254/metadata/v1/hostname)";
+                break;
+            case 'aws':
+                targetNameScript = String.raw`
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+TARGET_NAME=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)`;
+                break;
+            case 'time':
+                targetNameScript = "TARGET_NAME=target-$(date +\"%m%d-%H%M%S\")";
+                break;
+            case 'hostname':
+                targetNameScript = "TARGET_NAME=$(hostname)";
+                break;
+            default:
+                // Compile-time exhaustive check
+                // See: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
+                const _exhaustiveCheck: never = argv.targetNameScheme;
+                return _exhaustiveCheck;
+        }
+    } else {
+        // Target name scheme option: Manual
+        targetNameScript = `TARGET_NAME=\"${argv.targetName}\"`;
+    }
+
+    // Ensure that environment name argument is valid
+    const envs = await environments;
+    const environment = envs.find(envDetails => envDetails.name == argv.environment);
+    if (!environment) {
+        logger.error(`Environment ${argv.environment} does not exist`);
+        await cleanExit(1, logger);
+    }
+
+    const autodiscoveryScriptService = new AutoDiscoveryScriptService(configService, logger);
+    const autodiscoveryScriptResponse = await autodiscoveryScriptService.getAutodiscoveryScript(argv.os, targetNameScript, environment.id, argv.agentVersion);
+
+    if (argv.outputFile) {
+        await util.promisify(fs.writeFile)(argv.outputFile, autodiscoveryScriptResponse.autodiscoveryScript);
+    } else {
+        console.log(autodiscoveryScriptResponse.autodiscoveryScript);
+    }
+}

--- a/src/handlers/generate-bash/generate-bash.handler.ts
+++ b/src/handlers/generate-bash/generate-bash.handler.ts
@@ -14,28 +14,28 @@ export async function generateBashHandler(
     configService: ConfigService,
     environments: Promise<EnvironmentDetails[]>
 ) {
-    let targetNameScript: string = ""
+    let targetNameScript: string = '';
     if (argv.targetName === undefined) {
         switch (argv.targetNameScheme) {
-            case 'do':
-                targetNameScript = "TARGET_NAME=$(curl http://169.254.169.254/metadata/v1/hostname)";
-                break;
-            case 'aws':
-                targetNameScript = String.raw`
+        case 'do':
+            targetNameScript = 'TARGET_NAME=$(curl http://169.254.169.254/metadata/v1/hostname)';
+            break;
+        case 'aws':
+            targetNameScript = String.raw`
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 TARGET_NAME=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)`;
-                break;
-            case 'time':
-                targetNameScript = "TARGET_NAME=target-$(date +\"%m%d-%H%M%S\")";
-                break;
-            case 'hostname':
-                targetNameScript = "TARGET_NAME=$(hostname)";
-                break;
-            default:
-                // Compile-time exhaustive check
-                // See: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
-                const _exhaustiveCheck: never = argv.targetNameScheme;
-                return _exhaustiveCheck;
+            break;
+        case 'time':
+            targetNameScript = 'TARGET_NAME=target-$(date +"%m%d-%H%M%S")';
+            break;
+        case 'hostname':
+            targetNameScript = 'TARGET_NAME=$(hostname)';
+            break;
+        default:
+            // Compile-time exhaustive check
+            // See: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking
+            const _exhaustiveCheck: never = argv.targetNameScheme;
+            return _exhaustiveCheck;
         }
     } else {
         // Target name scheme option: Manual

--- a/src/services/auto-discovery-script/auto-discovery-script.service.ts
+++ b/src/services/auto-discovery-script/auto-discovery-script.service.ts
@@ -12,14 +12,14 @@ export class AutoDiscoveryScriptService extends HttpService
 
     public getAutodiscoveryScript(
         operatingSystem: string,
-        targetName: string,
+        targetNameScript: string,
         environmentId: string,
         agentVersion: string
     ): Promise<GetAutodiscoveryScriptResponse>
     {
         const request: GetAutodiscoveryScriptRequest = {
             apiUrl: `${this.configService.serviceUrl()}api/v1/`,
-            targetNameScript: `TARGET_NAME=\"${targetName}\"`,
+            targetNameScript: targetNameScript,
             envId: environmentId,
             agentVersion: agentVersion
         };


### PR DESCRIPTION
## Description of the change

Creates a new command `generate-bash`. This command replaces the `autodiscovery-script` command; in a future release, `autodiscovery-script` will be removed (i.e. `autodiscovery-script` is deprecated).

This command simplifies the user flow for SSH onboarding as one can call this command with no flags at all. The new script, found in backend PR bastionzero/webshell-backend#811, has been made universal--the script will detect the target machine's os.

The replacement command is also more on par with the webapp compared to the previous command; a `zli` user can specify a target name schema if they don't want to name the target explicitly/manually.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1028

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [x] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [x] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
