### PR TITLE
Fix connect so it can be used by non-tty interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -57,7 +57,9 @@ export async function createAndRunShell(
         // ref: https://nodejs.org/api/readline.html#readline_readline_emitkeypressevents_stream_interface
         const readline = require('readline');
         readline.emitKeypressEvents(process.stdin);
-        process.stdin.setRawMode(true);
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+        }
         process.stdin.on('keypress', (_, key) => observer.next(key.sequence));
     });
     source.pipe(bufferTime(50), filter(buffer => buffer.length > 0)).subscribe(keypresses => {


### PR DESCRIPTION
## Description of the change

`zli connect` now works from non-tty interfaces (e.g. calling `zli connect` from a python script).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1044

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
