### PR TITLE
Wrap kube commands under kube

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "tsc && cd bctl-go-daemon/bctl/daemon && go build",
     "package": "npm run copy-files && pkg .",
     "release": "npm run build && npm run package",
+    "release-dev": "tsc && npm run package",
     "copy-files": "copyfiles src/**/*.html src/**/*.css bctl-go-daemon/bctl/daemon/* dist/",
     "clean": "rimraf dist/ && rimraf bin/",
     "test": "jest",

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -216,8 +216,8 @@ export class CliDriver
                                 alias: 'm'
                             }
                         )
-                        .example('login Google', 'Login with Google')
-                        .example('login Microsoft --mfa 123456', 'Login with Microsoft and enter MFA');
+                        .example('$0 login Google', 'Login with Google')
+                        .example('$0 login Microsoft --mfa 123456', 'Login with Microsoft and enter MFA');
                 },
                 async (argv) => {
                     await loginHandler(this.configService, this.logger, argv, this.keySplittingService);
@@ -240,8 +240,8 @@ export class CliDriver
                                 alias: 't'
                             },
                         )
-                        .example('connect ssm-user@neat-target', 'SSM connect example, uniquely named ssm target')
-                        .example('connect --targetType dynamic ssm-user@my-dat-config', 'DAT connect example with a DAT configuration whose name is my-dat-config');
+                        .example('$0 connect ssm-user@neat-target', 'SSM connect example, uniquely named ssm target')
+                        .example('$0 connect --targetType dynamic ssm-user@my-dat-config', 'DAT connect example with a DAT configuration whose name is my-dat-config');
                 },
                 async (argv) => {
                     const parsedTarget = await disambiguateTarget(argv.targetType, argv.targetString, this.logger, this.dynamicConfigs, this.ssmTargets, this.envs);
@@ -263,7 +263,7 @@ export class CliDriver
                             default: -1,
                             demandOption: false
                         })
-                        .example('proxy admin@neat-cluster', 'Connect to neat-cluster as the admin Kube RBAC role');
+                        .example('$0 proxy admin@neat-cluster', 'Connect to neat-cluster as the admin Kube RBAC role');
                 },
                 async (argv) => {
                     if (argv.tunnelString) {
@@ -314,7 +314,7 @@ export class CliDriver
                         .positional('clusterName', {
                             type: 'string',
                         })
-                        .example('status test-cluster', '');
+                        .example('$0 status test-cluster', '');
                 },
                 async (argv) => {
                     await describeClusterHandler(argv.clusterName, this.configService, this.logger, this.clusterTargets, this.envs);
@@ -325,7 +325,7 @@ export class CliDriver
                 'Disconnect a Zli Daemon',
                 (yargs) => {
                     return yargs
-                        .example('disconnect', 'Disconnect a local Zli Daemon');
+                        .example('$0 disconnect', 'Disconnect a local Zli Daemon');
                 },
                 async (_) => {
                     await disconnectHandler(this.configService, this.logger);
@@ -339,7 +339,7 @@ export class CliDriver
                         .positional('connectionId', {
                             type: 'string',
                         })
-                        .example('attach d5b264c7-534c-4184-a4e4-3703489cb917', 'attach example, unique connection id');
+                        .example('$0 attach d5b264c7-534c-4184-a4e4-3703489cb917', 'attach example, unique connection id');
                 },
                 async (argv) => {
                     if (!isGuid(argv.connectionId)){
@@ -366,8 +366,8 @@ export class CliDriver
                                 alias: 'a'
                             }
                         )
-                        .example('close d5b264c7-534c-4184-a4e4-3703489cb917', 'close example, unique connection id')
-                        .example('close all', 'close all connections in cli-space');
+                        .example('$0 close d5b264c7-534c-4184-a4e4-3703489cb917', 'close example, unique connection id')
+                        .example('$0 close all', 'close all connections in cli-space');
                 },
                 async (argv) => {
                     if (! argv.all && ! isGuid(argv.connectionId)){
@@ -443,9 +443,9 @@ export class CliDriver
                                 alias: 'j',
                             }
                         )
-                        .example('lt -t ssm', 'List all SSM targets only')
-                        .example('lt -i', 'List all targets and show unique ids')
-                        .example('lt -e prod --json --silent', 'List all targets targets in prod, output as json, pipeable');
+                        .example('$0 lt -t ssm', 'List all SSM targets only')
+                        .example('$0 lt -i', 'List all targets and show unique ids')
+                        .example('$0 lt -e prod --json --silent', 'List all targets targets in prod, output as json, pipeable');
                 },
                 async (argv) => {
                     await listTargetsHandler(this.configService,this.logger, argv, this.dynamicConfigs, this.ssmTargets, this.clusterTargets, this.envs);
@@ -764,7 +764,7 @@ export class CliDriver
                                 alias: 'o'
                             }
                         )
-                        .example('autodiscovery-script centos sample-target-name Default', '');
+                        .example('$0 autodiscovery-script centos sample-target-name Default', '');
                 },
                 async (argv) => {
                     await autoDiscoveryScriptHandler(argv, this.logger, this.configService, this.envs);
@@ -804,9 +804,9 @@ export class CliDriver
                             type: 'string',
                             default: null
                         })
-                        .example('generate kubeYaml testcluster', '')
-                        .example('generate kubeConfig', '')
-                        .example('generate kubeYaml --labels testkey:testvalue', '');
+                        .example('$0 generate kubeYaml testcluster', '')
+                        .example('$0 generate kubeConfig', '')
+                        .example('$0 generate kubeYaml --labels testkey:testvalue', '');
                 },
                 async (argv) => {
                     if (argv.typeOfConfig == 'kubeConfig') {
@@ -824,8 +824,15 @@ export class CliDriver
                     await logoutHandler(this.configService, this.logger);
                 }
             )
-            .command('$0', 'Kubectl wrapper catch all', () => {}, async (_) => {
-                await bctlHandler(this.configService, this.logger);
+            .command('$0', 'Kubectl wrapper catch all', () => { }, async (_) => {
+                // Check to see what type of cli we are trying to proxy
+                var command = process.argv[2];
+                if (command == 'kube') {
+                    await bctlHandler(this.configService, this.logger);
+                } else {
+                    this.logger.error(`Unknown command passed ${command}`);
+                    await cleanExit(1, this.logger);
+                }
             })
             .option('configName', {type: 'string', choices: ['prod', 'stage', 'dev'], default: this.envMap['configName'], hidden: true})
             .option('debug', {type: 'boolean', default: false, describe: 'Flag to show debug logs'})

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -300,7 +300,7 @@ export class CliDriver
                                 alias: 'j',
                             }
                         )
-                        .example('policy --json', 'List all policies, output as json, pipeable');
+                        .example('$0 policy --json', 'List all policies, output as json, pipeable');
                 },
                 async (argv) => {
                     await listPoliciesHandler(argv, this.configService, this.logger, this.ssmTargets, this.dynamicConfigs, this.clusterTargets, this.envs);
@@ -465,7 +465,7 @@ export class CliDriver
                                 alias: 'j',
                             }
                         )
-                        .example('lc --json', 'List all open zli connections, output as json, pipeable');
+                        .example('$0 lc --json', 'List all open zli connections, output as json, pipeable');
                 },
                 async (argv) => {
                     await listConnectionsHandler(argv, this.configService, this.logger, this.ssmTargets);
@@ -518,9 +518,9 @@ export class CliDriver
                                 alias: 'j',
                             }
                         )
-                        .example('user --json', 'List all users, output as json, pipeable')
-                        .example('user --add test@test.com test-cluster', 'Adds the test@test.com IDP user to test-cluster policy')
-                        .example('user -d test@test.com test-cluster', 'Removes the test@test.com IDP user from test-cluster policy');
+                        .example('$0 user --json', 'List all users, output as json, pipeable')
+                        .example('$0 user --add test@test.com test-cluster', 'Adds the test@test.com IDP user to test-cluster policy')
+                        .example('$0 user -d test@test.com test-cluster', 'Removes the test@test.com IDP user from test-cluster policy');
                 },
                 async (argv) => {
                     if (!! argv.add) {
@@ -582,9 +582,9 @@ export class CliDriver
                                 alias: 'j',
                             }
                         )
-                        .example('group --json', 'List all groups, output as json, pipeable')
-                        .example('group --add cool-policy engineering-group', 'Adds the engineering-group IDP group to cool-policy policy')
-                        .example('group -d cool-policy engineering-group', 'Deletes the engineering-group IDP group from the cool-policy policy');
+                        .example('$0 group --json', 'List all groups, output as json, pipeable')
+                        .example('$0 group --add cool-policy engineering-group', 'Adds the engineering-group IDP group to cool-policy policy')
+                        .example('$0 group -d cool-policy engineering-group', 'Deletes the engineering-group IDP group from the cool-policy policy');
                 },
                 async (argv) => {
                     if (!! argv.add) {
@@ -646,9 +646,9 @@ export class CliDriver
                                 alias: 'j',
                             }
                         )
-                        .example('targetUser --json', 'List all target users, output as json, pipeable')
-                        .example('targetUser --add cool-policy centos', 'Adds the centos user to cool-policy')
-                        .example('targetUser -d test-cluster admin', 'Removes the admin RBAC Role to the test-cluster policy');
+                        .example('$0 targetUser --json', 'List all target users, output as json, pipeable')
+                        .example('$0 targetUser --add cool-policy centos', 'Adds the centos user to cool-policy')
+                        .example('$0 targetUser -d test-cluster admin', 'Removes the admin RBAC Role to the test-cluster policy');
                 },
                 async (argv) => {
                     if (!! argv.add) {

--- a/src/handlers/bctl.handler.ts
+++ b/src/handlers/bctl.handler.ts
@@ -1,11 +1,11 @@
 import { ConfigService } from '../../src/config.service/config.service';
 import { Logger } from '../../src/logger.service/logger';
 import { cleanExit } from './clean-exit.handler';
+import util from 'util';
+import { spawn, exec } from 'child_process';
 
 const { v4: uuidv4 } = require('uuid');
-const spawn = require('child_process').spawn;
-const { promisify } = require('util');
-const exec = promisify(require('child_process').exec)
+const execPromise = util.promisify(exec)
 
 
 export async function bctlHandler(configService: ConfigService, logger: Logger) {
@@ -43,9 +43,9 @@ export async function bctlHandler(configService: ConfigService, logger: Logger) 
 
         if (code != 0) {
             // Check to ensure they are using the right context
-            const currentContext = await exec('kubectl config current-context ');
+            const currentContext = await execPromise('kubectl config current-context ');
 
-            if (currentContext != 'bctl-server') {
+            if (currentContext.stdout != 'bctl-server') {
                 logger.warn('Make sure you using the correct kube config!');
             }
         }

--- a/src/handlers/bctl.handler.ts
+++ b/src/handlers/bctl.handler.ts
@@ -24,7 +24,7 @@ export async function bctlHandler(configService: ConfigService, logger: Logger) 
     const logId = uuidv4();
 
     // Now build our token
-    const kubeArgsRaw = process.argv.splice(2);
+    const kubeArgsRaw = process.argv.splice(3);
     const kubeArgsString = kubeArgsRaw.join(' ');
     const formattedToken = `${token}zli ${kubeArgsString}++++${logId}`;
 

--- a/src/handlers/bctl.handler.ts
+++ b/src/handlers/bctl.handler.ts
@@ -4,6 +4,8 @@ import { cleanExit } from './clean-exit.handler';
 
 const { v4: uuidv4 } = require('uuid');
 const spawn = require('child_process').spawn;
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec)
 
 
 export async function bctlHandler(configService: ConfigService, logger: Logger) {
@@ -41,10 +43,6 @@ export async function bctlHandler(configService: ConfigService, logger: Logger) 
 
         if (code != 0) {
             // Check to ensure they are using the right context
-            // Imported here since the code should usually be 0 
-            const { promisify } = require('util');
-            const exec = promisify(require('child_process').exec)
-
             const currentContext = await exec('kubectl config current-context ');
 
             if (currentContext != 'bctl-server') {

--- a/src/handlers/generate-kubeconfig.handler.ts
+++ b/src/handlers/generate-kubeconfig.handler.ts
@@ -20,7 +20,6 @@ export async function generateKubeconfigHandler(
 
         // Create and save key/cert
         const createCertPromise = new Promise<void>(async (resolve, reject) => {
-            // Define pem here as if the config has already been created, this codeblock will never be executed
             pem.createCertificate({ days: 999, selfSigned: true }, async function (err: any, keys: any) {
                 if (err) {
                     throw err;


### PR DESCRIPTION
## Description of the change

Couple of changes here:
* Talked with mike and the kube commands should go under `zli kube get pods`
* Thanos requested that we have a way to build the zli without building the agent , added that under `npm run release-dev`
* Realised we were not using `$0` in our `.example()` (ref: https://yargs.js.org/docs/#api-reference-examplecmd-desc), so I fixed that. See image as that adds the `zli` to the example:
![2021-08-31 at 4 12 PM](https://user-images.githubusercontent.com/28202162/131572078-b3b3aed1-a607-4bb8-8787-c4536f3f177d.jpg)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1008

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
