### PR TITLE
Ensure all vars are stored in vault

### DIFF
--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	serviceUrl, orgId, clusterName string
-	environmentId, activationToken string
+	serviceUrl, orgId, clusterName   string
+	environmentId, activationToken   string
+	idpProvider, namespace, idpOrgId string
 )
 
 const (
@@ -46,7 +47,7 @@ func main() {
 	}
 
 	// Connect to the control channel
-	control, err := cc.NewControlChannel(ccLogger, serviceUrl, activationToken, orgId, clusterName, environmentId, version, controlchannelTargetSelectHandler)
+	control, err := cc.NewControlChannel(ccLogger, serviceUrl, activationToken, orgId, clusterName, environmentId, version, idpProvider, idpOrgId, namespace, controlchannelTargetSelectHandler)
 	if err != nil {
 		select {} // TODO: Should we be trying again here?
 	}
@@ -148,6 +149,9 @@ func parseFlags() error {
 	orgId = os.Getenv("ORG_ID")
 	clusterName = os.Getenv("CLUSTER_NAME")
 	environmentId = os.Getenv("ENVIRONMENT")
+	idpProvider = os.Getenv("IDP_PROVIDER")
+	idpOrgId = os.Getenv("IDP_ORG_ID")
+	namespace = os.Getenv("NAMESPACE")
 
 	// Ensure we have all needed vars
 	missing := []string{}
@@ -161,8 +165,6 @@ func parseFlags() error {
 	case clusterName == "":
 		missing = append(missing, "clusterName")
 		fallthrough
-	// case environmentId == "":
-	// 	missing = append(missing, "environmentId")
 	case activationToken == "":
 		missing = append(missing, "activationToken")
 	}

--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	// Connect to the control channel
-	control, err := cc.NewControlChannel(ccLogger, serviceUrl, activationToken, orgId, clusterName, environmentId, agentVersion, idpProvider, idpOrgId, namespace, controlchannelTargetSelectHandler)
+	control, err := cc.NewControlChannel(ccLogger, serviceUrl, activationToken, orgId, clusterName, environmentId, agentVersion, controlchannelTargetSelectHandler)
 	if err != nil {
 		select {} // TODO: Should we be trying again here?
 	}

--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
+
+	ed "crypto/ed25519"
 
 	cc "bastionzero.com/bctl/v1/bctl/agent/controlchannel"
 	dc "bastionzero.com/bctl/v1/bctl/agent/datachannel"
+	"bastionzero.com/bctl/v1/bctl/agent/vault"
 	wsmsg "bastionzero.com/bctl/v1/bzerolib/channels/message"
 	lggr "bastionzero.com/bctl/v1/bzerolib/logger"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
@@ -20,7 +26,8 @@ var (
 )
 
 const (
-	hubEndpoint = "/api/v1/hub/kube-server"
+	hubEndpoint      = "/api/v1/hub/kube-server"
+	registerEndpoint = "/api/v1/kube/register-agent"
 
 	// Disable auto-reconnect
 	autoReconnect = false
@@ -29,14 +36,14 @@ const (
 
 func main() {
 	// Get agent version
-	version := getAgentVersion()
+	agentVersion := getAgentVersion()
 
 	// setup our loggers
 	logger, err := lggr.NewLogger(lggr.Debug, logFilePath, false)
 	if err != nil {
 		return
 	}
-	logger.AddAgentVersion(version)
+	logger.AddAgentVersion(agentVersion)
 
 	ccLogger := logger.GetControlchannelLogger()
 	dcLogger := logger.GetDatachannelLogger()
@@ -46,8 +53,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Populate keys if they haven't been generated already
+	err = newAgent(logger, serviceUrl, activationToken, agentVersion, orgId, environmentId, clusterName, idpProvider, idpOrgId, namespace)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+
 	// Connect to the control channel
-	control, err := cc.NewControlChannel(ccLogger, serviceUrl, activationToken, orgId, clusterName, environmentId, version, idpProvider, idpOrgId, namespace, controlchannelTargetSelectHandler)
+	control, err := cc.NewControlChannel(ccLogger, serviceUrl, activationToken, orgId, clusterName, environmentId, agentVersion, idpProvider, idpOrgId, namespace, controlchannelTargetSelectHandler)
 	if err != nil {
 		select {} // TODO: Should we be trying again here?
 	}
@@ -181,4 +195,65 @@ func getAgentVersion() string {
 	} else {
 		return "$AGENT_VERSION"
 	}
+}
+
+func newAgent(logger *lggr.Logger, serviceUrl string, activationToken string, agentVersion string, orgId string, environmentId string, clusterName string, idpProvider string, idpOrgId string, namespace string) error {
+	config, _ := vault.LoadVault()
+
+	// Check if vault is empty, if so generate a private, public key pair
+	if config.IsEmpty() {
+		logger.Info("Creating new agent secret")
+
+		if publicKey, privateKey, err := ed.GenerateKey(nil); err != nil {
+			return fmt.Errorf("error generating key pair: %v", err.Error())
+		} else {
+			pubkeyString := base64.StdEncoding.EncodeToString([]byte(publicKey))
+			privkeyString := base64.StdEncoding.EncodeToString([]byte(privateKey))
+			config.Data = vault.SecretData{
+				PublicKey:     pubkeyString,
+				PrivateKey:    privkeyString,
+				OrgId:         orgId,
+				ServiceUrl:    serviceUrl,
+				ClusterName:   clusterName,
+				EnvironmentId: environmentId,
+				Namespace:     namespace,
+				IdpProvider:   idpProvider,
+				IdpOrgId:      idpOrgId,
+			}
+
+			// Register with Bastion
+			logger.Info("Registering agent with Bastion")
+			register := cc.RegisterAgentMessage{
+				PublicKey:      pubkeyString,
+				ActivationCode: activationToken,
+				AgentVersion:   agentVersion,
+				OrgId:          orgId,
+				EnvironmentId:  environmentId,
+				ClusterName:    clusterName,
+			}
+
+			registerJson, err := json.Marshal(register)
+			if err != nil {
+				msg := fmt.Errorf("error marshalling registration data: %s", err)
+				return msg
+			}
+
+			// Make our POST request
+			response, err := http.Post("https://"+serviceUrl+registerEndpoint, "application/json",
+				bytes.NewBuffer(registerJson))
+			if err != nil || response.StatusCode != http.StatusOK {
+				rerr := fmt.Errorf("error making post request to register agent. Error: %s. Response: %v", err, response)
+				return rerr
+			}
+
+			// If the registration went ok, save the config
+			if err := config.Save(); err != nil {
+				return fmt.Errorf("error saving vault: %v", err.Error())
+			}
+		}
+	} else {
+		// If the vault isn't empty, don't do anything
+		logger.Info("Found Previous config data")
+	}
+	return nil
 }

--- a/bctl-go-daemon/bctl/agent/controlchannel/controlchannel.go
+++ b/bctl-go-daemon/bctl/agent/controlchannel/controlchannel.go
@@ -41,9 +41,6 @@ func NewControlChannel(logger *lggr.Logger,
 	clusterName string,
 	environmentId string,
 	agentVersion string,
-	idpProvider string,
-	idpOrgId string,
-	namespace string,
 	targetSelectHandler func(msg wsmsg.AgentMessage) (string, error)) (*ControlChannel, error) {
 
 	subLogger := logger.GetWebsocketLogger()

--- a/bctl-go-daemon/bctl/agent/controlchannel/controlchannel.go
+++ b/bctl-go-daemon/bctl/agent/controlchannel/controlchannel.go
@@ -1,13 +1,9 @@
 package controlchannel
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"regexp"
 	"sync"
 
@@ -15,9 +11,6 @@ import (
 	wsmsg "bastionzero.com/bctl/v1/bzerolib/channels/message"
 	ws "bastionzero.com/bctl/v1/bzerolib/channels/websocket"
 	lggr "bastionzero.com/bctl/v1/bzerolib/logger"
-	"golang.org/x/crypto/sha3"
-
-	ed "crypto/ed25519"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -26,7 +19,6 @@ import (
 
 const (
 	hubEndpoint       = "/api/v1/hub/kube-control"
-	registerEndpoint  = "/api/v1/kube/register-agent"
 	challengeEndpoint = "/api/v1/kube/get-challenge"
 	autoReconnect     = true
 )
@@ -56,21 +48,16 @@ func NewControlChannel(logger *lggr.Logger,
 
 	subLogger := logger.GetWebsocketLogger()
 
-	// Populate keys if they haven't been generated already
-	config, err := newAgent(serviceUrl, activationToken, agentVersion, orgId, environmentId, clusterName, idpProvider, idpOrgId, namespace)
-	if err != nil {
-		logger.Error(err)
-		return &ControlChannel{}, err
-	}
+	// Load in our saved config
+	config, _ := vault.LoadVault()
 
 	// Create our headers and params, headers are empty
 	headers := make(map[string]string)
 
 	// Make and add our params
 	params := map[string]string{
-		"solved_challange": solvedChallenge,
-		"public_key":       config.Data.PublicKey,
-		"agent_version":    agentVersion,
+		"public_key":    config.Data.PublicKey,
+		"agent_version": agentVersion,
 
 		// Why do we need these?  Can we remove them?
 		"org_id":         orgId,
@@ -131,55 +118,6 @@ func (c *ControlChannel) Receive(agentMessage wsmsg.AgentMessage) error {
 		}
 	}
 	return nil
-}
-
-func getAndSolveChallenge(orgId string, clusterName string, serviceUrl string, privateKey string) (string, error) {
-	// Get Challenge
-	challengeRequest := GetChallengeMessage{
-		OrgId:       orgId,
-		ClusterName: clusterName,
-	}
-
-	challengeJson, err := json.Marshal(challengeRequest)
-	if err != nil {
-		return "", errors.New("error marshalling register data")
-	}
-
-	// Make our POST request
-	response, err := http.Post(
-		"https://"+serviceUrl+challengeEndpoint,
-		"application/json",
-		bytes.NewBuffer(challengeJson))
-	if err != nil || response.StatusCode != http.StatusOK {
-		rerr := fmt.Errorf("error making post request to challenge agent. Error: %v. Response: %v", err, response)
-		return "", rerr
-	}
-	defer response.Body.Close()
-
-	// Extract the challenge
-	responseDecoded := GetChallengeResponse{}
-	json.NewDecoder(response.Body).Decode(&responseDecoded)
-
-	// Solve Challenge
-	return SignChallenge(privateKey, responseDecoded.Challenge)
-}
-
-// TODO: make a bzerolib signing function
-func SignChallenge(privateKey string, challenge string) (string, error) {
-	keyBytes, _ := base64.StdEncoding.DecodeString(privateKey)
-	if len(keyBytes) != 64 {
-		return "", fmt.Errorf("invalid private key length: %v", len(keyBytes))
-	}
-	privkey := ed.PrivateKey(keyBytes)
-
-	hashBits := sha3.Sum256([]byte(challenge))
-
-	sig := ed.Sign(privkey, hashBits[:])
-
-	// Convert the signature to base64 string
-	sigBase64 := base64.StdEncoding.EncodeToString(sig)
-
-	return sigBase64, nil
 }
 
 func healthCheck() ([]byte, error) {
@@ -248,65 +186,4 @@ func healthCheck() ([]byte, error) {
 
 	aliveBytes, _ := json.Marshal(alive)
 	return aliveBytes, nil
-}
-
-func newAgent(logger *lggr.Logger, serviceUrl string, activationToken string, agentVersion string, orgId string, environmentId string, clusterName string, idpProvider string, idpOrgId string, namespace string) (*vault.Vault, error) {
-	config, _ := vault.LoadVault()
-
-	// Check if vault is empty, if so generate a private, public key pair
-	if config.IsEmpty() {
-		logger.Info("Creating new agent secret")
-
-		if publicKey, privateKey, err := ed.GenerateKey(nil); err != nil {
-			return nil, fmt.Errorf("error generating key pair: %v", err.Error())
-		} else {
-			pubkeyString := base64.StdEncoding.EncodeToString([]byte(publicKey))
-			privkeyString := base64.StdEncoding.EncodeToString([]byte(privateKey))
-			config.Data = vault.SecretData{
-				PublicKey:     pubkeyString,
-				PrivateKey:    privkeyString,
-				OrgId:         orgId,
-				ServiceUrl:    serviceUrl,
-				ClusterName:   clusterName,
-				EnvironmentId: environmentId,
-				Namespace:     namespace,
-				IdpProvider:   idpProvider,
-				IdpOrgId:      idpOrgId,
-			}
-
-			// Register with Bastion
-			logger.Info("Registering agent with Bastion")
-			register := RegisterAgentMessage{
-				PublicKey:      pubkeyString,
-				ActivationCode: activationToken,
-				AgentVersion:   agentVersion,
-				OrgId:          orgId,
-				EnvironmentId:  environmentId,
-				ClusterName:    clusterName,
-			}
-
-			registerJson, err := json.Marshal(register)
-			if err != nil {
-				msg := fmt.Errorf("error marshalling registration data: %s", err)
-				return nil, msg
-			}
-
-			// Make our POST request
-			response, err := http.Post("https://"+serviceUrl+registerEndpoint, "application/json",
-				bytes.NewBuffer(registerJson))
-			if err != nil || response.StatusCode != http.StatusOK {
-				rerr := fmt.Errorf("error making post request to register agent. Error: %s. Response: %v", err, response)
-				return nil, rerr
-			}
-
-			// If the registration went ok, save the config
-			if err := config.Save(); err != nil {
-				return nil, fmt.Errorf("error saving vault: %v", err.Error())
-			}
-		}
-	} else {
-		// If the vault isn't empty, don't do anything
-		logger.Info("Found Previous config data")
-	}
-	return config, nil
 }

--- a/bctl-go-daemon/bctl/agent/vault/vault.go
+++ b/bctl-go-daemon/bctl/agent/vault/vault.go
@@ -25,8 +25,15 @@ type Vault struct {
 }
 
 type SecretData struct {
-	PublicKey  string
-	PrivateKey string
+	PublicKey     string
+	PrivateKey    string
+	OrgId         string
+	ServiceUrl    string
+	ClusterName   string
+	EnvironmentId string
+	Namespace     string
+	IdpProvider   string
+	IdpOrgId      string
 }
 
 func LoadVault() (*Vault, error) {

--- a/bctl-go-daemon/bzerolib/keysplitting/bzcert/bzcert.go
+++ b/bctl-go-daemon/bzerolib/keysplitting/bzcert/bzcert.go
@@ -25,8 +25,8 @@ type BZCert struct {
 	SignatureOnRand string `json:"signatureOnRand"`
 }
 
-func (b *BZCert) Verify() (string, time.Time, error) {
-	verifier := NewBZCertVerifier(b)
+func (b *BZCert) Verify(idpProvider string, idpOrgId string) (string, time.Time, error) {
+	verifier := NewBZCertVerifier(b, idpProvider, idpOrgId)
 
 	if _, err := verifier.VerifyIdToken(b.InitialIdToken, true, true); err != nil {
 		return "", time.Time{}, err

--- a/bctl-go-daemon/bzerolib/keysplitting/bzcert/bzcertverifier.go
+++ b/bctl-go-daemon/bzerolib/keysplitting/bzcert/bzcertverifier.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"time"
 
 	ed "crypto/ed25519"
@@ -42,9 +41,8 @@ const (
 	Custom    ProviderType = "custom"
 )
 
-func NewBZCertVerifier(bzcert *BZCert) IBZCertVerifier {
-	orgId := os.Getenv("IDP_ORG_ID")
-	provider := ProviderType(os.Getenv("IDP_PROVIDER"))
+func NewBZCertVerifier(bzcert *BZCert, idpProvider string, idpOrgId string) IBZCertVerifier {
+	provider := ProviderType(idpProvider)
 	// customIss := os.Getenv("CUSTOM_IDP")
 
 	iss := ""
@@ -52,7 +50,7 @@ func NewBZCertVerifier(bzcert *BZCert) IBZCertVerifier {
 	case Google:
 		iss = googleUrl
 	case Microsoft:
-		iss = getMicrosoftIssuerUrl(orgId)
+		iss = getMicrosoftIssuerUrl(idpOrgId)
 	// case Custom:
 	// 	iss = customIss // Any valid iss requires a discovery document
 	default:
@@ -60,7 +58,7 @@ func NewBZCertVerifier(bzcert *BZCert) IBZCertVerifier {
 	}
 
 	return &BZCertVerifier{
-		orgId:       orgId,
+		orgId:       idpOrgId,
 		orgProvider: provider,
 		iss:         iss,
 		cert:        bzcert,


### PR DESCRIPTION
## Description of the change

Ensure that we are using `os.Getenv()` as little as possible, and always pulling from a source of truth. We store the org info in the vault when we generate a new pub/private key. And then pull from there. We do not pull every time we need to make a message request (as that would not really be sustainable), rather we pull once when we build out key splitting object when we build the datachannel/plugin and pass those values to the function that needs them. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1030

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
