### PR TITLE
Catch when the kubeconfig has not been created yet

### DIFF
--- a/src/handlers/status.handler.ts
+++ b/src/handlers/status.handler.ts
@@ -9,7 +9,7 @@ export async function kubeStatusHandler(
     // First get the status from the config service
     const kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig['localPid'] == null) {
+    if (kubeConfig === null || kubeConfig['localPid'] === null) {
         logger.warn('No Kube daemon running');
     } else {
         // Check if the pid is still alive


### PR DESCRIPTION
## Description of the change

Fixes issue when kubeconfig has not been defined yet. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
