### PR TITLE
Fix stdout stream

### DIFF
--- a/bctl-go-daemon/bctl-agent.service
+++ b/bctl-go-daemon/bctl-agent.service
@@ -3,8 +3,8 @@ Description=Bctl-Agent
 
 [Service]
 ExecStart=/bctl-agent-files/start-dev.sh
-# StandardOutput=file:/var/log/bzero/bctl-agent.log
-# StandardError=file:/var/log/bzero/bctl-agent.log
+StandardOutput=file:/var/log/bzero/bctl-agent.log
+StandardError=file:/var/log/bzero/bctl-agent.log
 
 [Install]
 WantedBy=multi-user.target

--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -31,7 +31,6 @@ const (
 
 	// Disable auto-reconnect
 	autoReconnect = false
-	logFilePath   = "/var/log/cwc/bctl-agent-logs.log"
 )
 
 func main() {
@@ -39,7 +38,7 @@ func main() {
 	agentVersion := getAgentVersion()
 
 	// setup our loggers
-	logger, err := lggr.NewLogger(lggr.Debug, logFilePath)
+	logger, err := lggr.NewLogger(lggr.Debug, "")
 	if err != nil {
 		return
 	}

--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -31,15 +31,22 @@ const (
 
 	// Disable auto-reconnect
 	autoReconnect = false
-	logFilePath   = "/var/log/cwc/bctl-agent.log"
+	logFilePath   = "/var/log/cwc/bctl-agent-logs.log"
 )
 
 func main() {
 	// Get agent version
 	agentVersion := getAgentVersion()
 
+	// Check if we are in dev mode
+	devMode := os.Getenv("DEV")
+	stdoutStream := true
+	if devMode == "true" {
+		stdoutStream = false
+	}
+
 	// setup our loggers
-	logger, err := lggr.NewLogger(lggr.Debug, logFilePath, false)
+	logger, err := lggr.NewLogger(lggr.Debug, logFilePath, stdoutStream)
 	if err != nil {
 		return
 	}

--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -39,7 +39,7 @@ func main() {
 	agentVersion := getAgentVersion()
 
 	// setup our loggers
-	logger, err := lggr.NewLogger(lggr.Debug, logFilePath, true)
+	logger, err := lggr.NewLogger(lggr.Debug, logFilePath)
 	if err != nil {
 		return
 	}

--- a/bctl-go-daemon/bctl/agent/agent.go
+++ b/bctl-go-daemon/bctl/agent/agent.go
@@ -38,15 +38,8 @@ func main() {
 	// Get agent version
 	agentVersion := getAgentVersion()
 
-	// Check if we are in dev mode
-	devMode := os.Getenv("DEV")
-	stdoutStream := true
-	if devMode == "true" {
-		stdoutStream = false
-	}
-
 	// setup our loggers
-	logger, err := lggr.NewLogger(lggr.Debug, logFilePath, stdoutStream)
+	logger, err := lggr.NewLogger(lggr.Debug, logFilePath, true)
 	if err != nil {
 		return
 	}

--- a/bctl-go-daemon/bctl/daemon/daemon.go
+++ b/bctl-go-daemon/bctl/daemon/daemon.go
@@ -31,7 +31,7 @@ func main() {
 	// Setup our loggers
 	// TODO: Pass in debug level as flag
 	// TODO: Pass in stdout output as flag?
-	logger, err := lggr.NewLogger(lggr.Debug, getLogFilePath(), true)
+	logger, err := lggr.NewLogger(lggr.Debug, getLogFilePath())
 	if err != nil {
 		os.Exit(1)
 	}

--- a/bctl-go-daemon/bzerolib/logger/logger.go
+++ b/bctl-go-daemon/bzerolib/logger/logger.go
@@ -25,7 +25,7 @@ type Logger struct {
 	logger zerolog.Logger
 }
 
-func NewLogger(debugLevel DebugLevel, logFilePath string, stdout bool) (*Logger, error) {
+func NewLogger(debugLevel DebugLevel, logFilePath string) (*Logger, error) {
 	// Let's us display stack info on errors
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	zerolog.SetGlobalLevel(debugLevel)
@@ -37,18 +37,12 @@ func NewLogger(debugLevel DebugLevel, logFilePath string, stdout bool) (*Logger,
 		return &Logger{}, err
 	}
 
-	if stdout {
-		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
-		multi := zerolog.MultiLevelWriter(consoleWriter, logFile)
+	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
+	multi := zerolog.MultiLevelWriter(consoleWriter)
 
-		return &Logger{
-			logger: zerolog.New(multi).With().Timestamp().Logger(),
-		}, nil
-	} else {
-		return &Logger{
-			logger: zerolog.New(logFile).With().Timestamp().Logger(),
-		}, nil
-	}
+	return &Logger{
+		logger: zerolog.New(multi).With().Logger(),
+	}, nil
 }
 
 func (l *Logger) AddAgentVersion(version string) {

--- a/bctl-go-daemon/bzerolib/logger/logger.go
+++ b/bctl-go-daemon/bzerolib/logger/logger.go
@@ -45,11 +45,8 @@ func NewLogger(debugLevel DebugLevel, logFilePath string) (*Logger, error) {
 			logger: zerolog.New(multi).With().Timestamp().Logger(),
 		}, nil
 	} else {
-		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
-		multi := zerolog.MultiLevelWriter(consoleWriter)
-
 		return &Logger{
-			logger: zerolog.New(multi).With().Timestamp().Logger(),
+			logger: zerolog.New(os.Stdout).With().Timestamp.Logger(),
 		}, nil
 	}
 }

--- a/bctl-go-daemon/bzerolib/logger/logger.go
+++ b/bctl-go-daemon/bzerolib/logger/logger.go
@@ -31,18 +31,27 @@ func NewLogger(debugLevel DebugLevel, logFilePath string) (*Logger, error) {
 	zerolog.SetGlobalLevel(debugLevel)
 
 	// If the log file doesn't exist, create it, or append to the file
-	logFile, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Printf("error: %s", err)
-		return &Logger{}, err
+	if logFilePath != "" {
+		logFile, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			log.Printf("error: %s", err)
+			return &Logger{}, err
+		}
+
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
+		multi := zerolog.MultiLevelWriter(consoleWriter, logFile)
+
+		return &Logger{
+			logger: zerolog.New(multi).With().Timestamp().Logger(),
+		}, nil
+	} else {
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
+		multi := zerolog.MultiLevelWriter(consoleWriter)
+
+		return &Logger{
+			logger: zerolog.New(multi).With().Timestamp().Logger(),
+		}, nil
 	}
-
-	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout}
-	multi := zerolog.MultiLevelWriter(consoleWriter)
-
-	return &Logger{
-		logger: zerolog.New(multi).With().Logger(),
-	}, nil
 }
 
 func (l *Logger) AddAgentVersion(version string) {


### PR DESCRIPTION
## Description of the change

This pr defaults to all logs streaming to stdout. This allows us to get nice formatted log in the dockerhub image and in our dev tools: 
![2021-09-07 at 2 08 PM](https://user-images.githubusercontent.com/28202162/132391198-23743cdb-316b-47d4-9ba4-73aec815548d.jpg)
![2021-09-07 at 1 59 PM](https://user-images.githubusercontent.com/28202162/132391206-6cec70b6-4c29-41d5-8dd5-4dacb0528612.jpg)


I left the functionality so that we can disable this behavior in the future. But tested it by building a new image + deploying a new dev agent and it was working. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
