### PR TITLE
Ensure that close message gets bubbled up to Daemon

### DIFF
--- a/kube-go-assets/bctl/daemon/datachannel/datachannel.go
+++ b/kube-go-assets/bctl/daemon/datachannel/datachannel.go
@@ -98,15 +98,17 @@ func NewDataChannel(logger *lggr.Logger,
 						ret.logger.Error(err)
 					}
 				}()
-			case <-ret.websocket.DoneChan:
+			case message := <-ret.websocket.DoneChan:
 				// The websocket has been closed
-				msg := "Websocket has been closed, closing datachannel"
+				msg := fmt.Sprintf("Websocket has been closed, closing datachannel: %s", message)
 				ret.logger.Info(msg)
-				cancel()
 
 				// Send a message to our done channel so kubectl can display it
-				ret.doneChannel <- msg
-				return
+				ret.doneChannel <- message
+
+				// Do not return, so the user can see the error, just sleep forever
+				// We also do not cancel the context for the same reason
+				select {}
 			}
 		}
 	}()

--- a/kube-go-assets/bzerolib/channels/websocket/websocket.go
+++ b/kube-go-assets/bzerolib/channels/websocket/websocket.go
@@ -48,7 +48,7 @@ type Websocket struct {
 	// These are the channels for recieving and sending messages and done
 	InputChan  chan wsmsg.AgentMessage
 	OutputChan chan wsmsg.AgentMessage
-	DoneChan   chan bool
+	DoneChan   chan string
 
 	// Function for figuring out correct Target SignalR Hub
 	targetSelectHandler func(msg wsmsg.AgentMessage) (string, error)
@@ -84,7 +84,7 @@ func NewWebsocket(ctx context.Context,
 		logger:              logger,
 		InputChan:           make(chan wsmsg.AgentMessage, 200),
 		OutputChan:          make(chan wsmsg.AgentMessage, 200),
-		DoneChan:            make(chan bool),
+		DoneChan:            make(chan string),
 		targetSelectHandler: targetSelectHandler,
 		getChallenge:        getChallenge,
 		autoReconnect:       autoReconnect,
@@ -107,7 +107,7 @@ func NewWebsocket(ctx context.Context,
 			default:
 				if err := ret.Receive(); err != nil {
 					ret.logger.Error(err)
-					ret.DoneChan <- true
+					ret.DoneChan <- fmt.Sprint(err)
 					return
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.1.10",
+  "version": "5.1.11",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description of the change

Ensure that when we receive a close message from the bastion, it gets bubbled up to the daemon. We had this functionality at some point, but looks like it was lost in the many rebase's refactors that occured


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1077

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
