### PR TITLE
Ensure that SPDY Stream errors get bubbled up to the user

### DIFF
--- a/bctl-go-daemon/bctl/agent/plugin/kube/actions/exec/exec.go
+++ b/bctl-go-daemon/bctl/agent/plugin/kube/actions/exec/exec.go
@@ -172,11 +172,18 @@ func (e *ExecAction) StartExec(startExecRequest KubeExecStartActionPayload) (str
 			Tty:               true, // TODO: We dont always want tty
 		})
 
-		stdoutWriter.Write([]byte(EscChar))
+		// First check the error to bubble up to the user
 		if err != nil {
+			// Log the error
 			rerr := fmt.Errorf("error in SPDY stream: %s", err)
 			e.logger.Error(rerr)
+
+			// Also write the error to our stdoutWriter so the user can see it
+			stdoutWriter.Write([]byte(fmt.Sprint(err)))
 		}
+
+		// Now close the stream
+		stdoutWriter.Write([]byte(EscChar))
 
 		e.closed = true
 	}()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description of the change

Ensure that spdy error gets bubbled up to the user for exec
![2021-09-16 at 5 19 PM](https://user-images.githubusercontent.com/28202162/133687099-72d1a8d5-503b-43a7-a5ce-d187a7f52901.jpg)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1075

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
