### PR TITLE
Always perform an undefined check for kubeConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.1.9",
+  "version": "5.1.10",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/handlers/bctl.handler.ts
+++ b/src/handlers/bctl.handler.ts
@@ -11,7 +11,7 @@ const execPromise = util.promisify(exec);
 export async function bctlHandler(configService: ConfigService, logger: Logger, listOfCommands: string[]) {
     // Check if daemon is even running
     const kubeConfig = configService.getKubeConfig();
-    if (kubeConfig !== undefined && kubeConfig['localPid'] === null) {
+    if (kubeConfig !== null && kubeConfig['localPid'] === null) {
         logger.warn('No Kube daemon running');
         await cleanExit(1, logger);
     }

--- a/src/handlers/bctl.handler.ts
+++ b/src/handlers/bctl.handler.ts
@@ -11,7 +11,7 @@ const execPromise = util.promisify(exec);
 export async function bctlHandler(configService: ConfigService, logger: Logger, listOfCommands: string[]) {
     // Check if daemon is even running
     const kubeConfig = configService.getKubeConfig();
-    if (kubeConfig['localPid'] == null) {
+    if (kubeConfig !== undefined && kubeConfig['localPid'] === null) {
         logger.warn('No Kube daemon running');
         await cleanExit(1, logger);
     }

--- a/src/handlers/bctl.handler.ts
+++ b/src/handlers/bctl.handler.ts
@@ -11,7 +11,7 @@ const execPromise = util.promisify(exec);
 export async function bctlHandler(configService: ConfigService, logger: Logger, listOfCommands: string[]) {
     // Check if daemon is even running
     const kubeConfig = configService.getKubeConfig();
-    if (kubeConfig !== null && kubeConfig['localPid'] === null) {
+    if (kubeConfig['localPid'] == null) {
         logger.warn('No Kube daemon running');
         await cleanExit(1, logger);
     }

--- a/src/handlers/generate-kube/generate-kubeconfig.handler.ts
+++ b/src/handlers/generate-kube/generate-kubeconfig.handler.ts
@@ -16,7 +16,7 @@ export async function generateKubeconfigHandler(
     // Check if we already have generated a cert/key
     let kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig === null || kubeConfig['keyPath'] === null) {
+    if (kubeConfig['keyPath'] == null) {
         logger.info('No KubeConfig has been generated before, generating key and cert for local daemon...');
 
         // Create and save key/cert

--- a/src/handlers/generate-kube/generate-kubeconfig.handler.ts
+++ b/src/handlers/generate-kube/generate-kubeconfig.handler.ts
@@ -16,7 +16,7 @@ export async function generateKubeconfigHandler(
     // Check if we already have generated a cert/key
     let kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig == undefined) {
+    if (kubeConfig === undefined && kubeConfig['keyPath'] === null) {
         logger.info('No KubeConfig has been generated before, generating key and cert for local daemon...');
 
         // Create and save key/cert

--- a/src/handlers/generate-kube/generate-kubeconfig.handler.ts
+++ b/src/handlers/generate-kube/generate-kubeconfig.handler.ts
@@ -16,7 +16,7 @@ export async function generateKubeconfigHandler(
     // Check if we already have generated a cert/key
     let kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig === undefined && kubeConfig['keyPath'] === null) {
+    if (kubeConfig === null || kubeConfig['keyPath'] === null) {
         logger.info('No KubeConfig has been generated before, generating key and cert for local daemon...');
 
         // Create and save key/cert

--- a/src/handlers/logout.handler.ts
+++ b/src/handlers/logout.handler.ts
@@ -12,7 +12,7 @@ export async function logoutHandler(configService: ConfigService, logger: Logger
 
     logger.info('Closing any existing Kube Proxy Connections');
     const kubeConfig = configService.getKubeConfig();
-    if (kubeConfig !== null && kubeConfig['localPid'] !== null) {
+    if (kubeConfig['localPid'] != null) {
         killDaemon(configService);
     }
 

--- a/src/handlers/logout.handler.ts
+++ b/src/handlers/logout.handler.ts
@@ -12,7 +12,7 @@ export async function logoutHandler(configService: ConfigService, logger: Logger
 
     logger.info('Closing any existing Kube Proxy Connections');
     const kubeConfig = configService.getKubeConfig();
-    if (kubeConfig !== null && kubeConfig['localPid'] !== null) {
+    if (kubeConfig !== undefined && kubeConfig['localPid'] !== null) {
         killDaemon(configService);
     }
 

--- a/src/handlers/logout.handler.ts
+++ b/src/handlers/logout.handler.ts
@@ -12,7 +12,7 @@ export async function logoutHandler(configService: ConfigService, logger: Logger
 
     logger.info('Closing any existing Kube Proxy Connections');
     const kubeConfig = configService.getKubeConfig();
-    if (kubeConfig !== undefined && kubeConfig['localPid'] !== null) {
+    if (kubeConfig !== null && kubeConfig['localPid'] !== null) {
         killDaemon(configService);
     }
 

--- a/src/handlers/tunnel/start-kube-daemon.handler.ts
+++ b/src/handlers/tunnel/start-kube-daemon.handler.ts
@@ -44,7 +44,7 @@ export async function startKubeDaemonHandler(argv: yargs.Arguments<tunnelArgs>, 
     }
 
 
-    if (kubeConfig['localPid'] != null) {
+    if (kubeConfig !== undefined && kubeConfig['localPid'] !== null) {
         killDaemon(configService);
     }
 

--- a/src/handlers/tunnel/start-kube-daemon.handler.ts
+++ b/src/handlers/tunnel/start-kube-daemon.handler.ts
@@ -38,13 +38,13 @@ export async function startKubeDaemonHandler(argv: yargs.Arguments<tunnelArgs>, 
     const kubeConfig = configService.getKubeConfig();
 
     // Make sure the user has created a kubeConfig before
-    if (kubeConfig === null || kubeConfig['keyPath'] === null) {
+    if (kubeConfig['keyPath'] == null) {
         logger.error('Please make sure you have created your kubeconfig before running proxy. You can do this via "zli generate kubeConfig"');
         await cleanExit(1, logger);
     }
 
 
-    if (kubeConfig !== null && kubeConfig['localPid'] !== null) {
+    if (kubeConfig['localPid'] != null) {
         killDaemon(configService);
     }
 

--- a/src/handlers/tunnel/start-kube-daemon.handler.ts
+++ b/src/handlers/tunnel/start-kube-daemon.handler.ts
@@ -38,13 +38,13 @@ export async function startKubeDaemonHandler(argv: yargs.Arguments<tunnelArgs>, 
     const kubeConfig = configService.getKubeConfig();
 
     // Make sure the user has created a kubeConfig before
-    if (kubeConfig === undefined && kubeConfig['keyPath'] === null) {
+    if (kubeConfig === null || kubeConfig['keyPath'] === null) {
         logger.error('Please make sure you have created your kubeconfig before running proxy. You can do this via "zli generate kubeConfig"');
         await cleanExit(1, logger);
     }
 
 
-    if (kubeConfig !== undefined && kubeConfig['localPid'] !== null) {
+    if (kubeConfig !== null && kubeConfig['localPid'] !== null) {
         killDaemon(configService);
     }
 

--- a/src/handlers/tunnel/start-kube-daemon.handler.ts
+++ b/src/handlers/tunnel/start-kube-daemon.handler.ts
@@ -38,7 +38,7 @@ export async function startKubeDaemonHandler(argv: yargs.Arguments<tunnelArgs>, 
     const kubeConfig = configService.getKubeConfig();
 
     // Make sure the user has created a kubeConfig before
-    if (kubeConfig == undefined) {
+    if (kubeConfig === undefined && kubeConfig['keyPath'] === null) {
         logger.error('Please make sure you have created your kubeconfig before running proxy. You can do this via "zli generate kubeConfig"');
         await cleanExit(1, logger);
     }

--- a/src/handlers/tunnel/status.handler.ts
+++ b/src/handlers/tunnel/status.handler.ts
@@ -9,7 +9,7 @@ export async function kubeStatusHandler(
     // First get the status from the config service
     const kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig === null || kubeConfig['localPid'] === null) {
+    if (kubeConfig['localPid'] == null) {
         logger.warn('No Kube daemon running');
     } else {
         // Check if the pid is still alive

--- a/src/handlers/tunnel/status.handler.ts
+++ b/src/handlers/tunnel/status.handler.ts
@@ -9,7 +9,7 @@ export async function kubeStatusHandler(
     // First get the status from the config service
     const kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig === undefined || kubeConfig['localPid'] === null) {
+    if (kubeConfig === null || kubeConfig['localPid'] === null) {
         logger.warn('No Kube daemon running');
     } else {
         // Check if the pid is still alive

--- a/src/handlers/tunnel/status.handler.ts
+++ b/src/handlers/tunnel/status.handler.ts
@@ -9,7 +9,7 @@ export async function kubeStatusHandler(
     // First get the status from the config service
     const kubeConfig = configService.getKubeConfig();
 
-    if (kubeConfig === null || kubeConfig['localPid'] === null) {
+    if (kubeConfig === undefined || kubeConfig['localPid'] === null) {
         logger.warn('No Kube daemon running');
     } else {
         // Check if the pid is still alive

--- a/src/services/config/config.service.ts
+++ b/src/services/config/config.service.ts
@@ -8,17 +8,8 @@ import { IdP } from '../common.types';
 import { ClientSecretResponse } from '../token/token.messages';
 import { TokenService } from '../token/token.service';
 import { UserSummary } from '../user/user.types';
+import { KubeConfig, getDefaultKubeConfig } from '../kube/kube.service';
 
-export interface KubeConfig {
-    keyPath: string,
-    certPath: string,
-    token: string,
-    localHost: string,
-    localPort: number,
-    localPid: number,
-    assumeRole: string,
-    assumeCluster: string,
-}
 
 // refL: https://github.com/sindresorhus/conf/blob/master/test/index.test-d.ts#L5-L14
 type BastionZeroConfigSchema = {
@@ -64,7 +55,7 @@ export class ConfigService implements ConfigInterface {
                 whoami: undefined,
                 sshKeyPath: undefined,
                 keySplitting: getDefaultKeysplittingConfig(),
-                kubeConfig: undefined
+                kubeConfig: getDefaultKubeConfig()
             },
             accessPropertiesByDotNotation: true,
             clearInvalidConfig: true,    // if config is invalid, delete

--- a/src/services/kube/kube.service.ts
+++ b/src/services/kube/kube.service.ts
@@ -89,5 +89,5 @@ export function getDefaultKubeConfig(): KubeConfig {
         localPid: null,
         assumeRole: null,
         assumeCluster: null,
-    }
+    };
 }

--- a/src/services/kube/kube.service.ts
+++ b/src/services/kube/kube.service.ts
@@ -48,7 +48,7 @@ export async function killDaemon(configService: ConfigService) {
     const kubeConfig = configService.getKubeConfig();
 
     // then kill the daemon
-    if (kubeConfig['localPid'] != null) {
+    if (kubeConfig !== undefined && kubeConfig['localPid'] != null) {
         // First try to kill the process
         if (process.platform === 'win32') {
             spawn('taskkill', ['/F', '/T', '/PID', kubeConfig['localPid'].toString()]);

--- a/src/services/kube/kube.service.ts
+++ b/src/services/kube/kube.service.ts
@@ -5,6 +5,17 @@ import { Logger } from '../logger/logger.service';
 import { GetKubeUnregisteredAgentYamlResponse, GetKubeUnregisteredAgentYamlRequest, GetUserInfoResponse, GetUserInfoRequest } from './kube.mesagges';
 import { ClusterSummary } from './kube.types';
 
+export interface KubeConfig {
+    keyPath: string,
+    certPath: string,
+    token: string,
+    localHost: string,
+    localPort: number,
+    localPid: number,
+    assumeRole: string,
+    assumeCluster: string,
+}
+
 export class KubeService extends HttpService
 {
     constructor(configService: ConfigService, logger: Logger)
@@ -65,5 +76,18 @@ export async function killDaemon(configService: ConfigService) {
         return true;
     } else {
         return false;
+    }
+}
+
+export function getDefaultKubeConfig(): KubeConfig {
+    return {
+        keyPath: null,
+        certPath: null,
+        token: null,
+        localHost: null,
+        localPort: null,
+        localPid: null,
+        assumeRole: null,
+        assumeCluster: null,
     }
 }

--- a/src/services/kube/kube.service.ts
+++ b/src/services/kube/kube.service.ts
@@ -59,7 +59,7 @@ export async function killDaemon(configService: ConfigService) {
     const kubeConfig = configService.getKubeConfig();
 
     // then kill the daemon
-    if (kubeConfig !== undefined && kubeConfig['localPid'] != null) {
+    if ( kubeConfig['localPid'] != null) {
         // First try to kill the process
         if (process.platform === 'win32') {
             spawn('taskkill', ['/F', '/T', '/PID', kubeConfig['localPid'].toString()]);


### PR DESCRIPTION
## Description of the change

Had a bug where we would throw an error if the kubeconfig was not created in the zli config. This PR fixes that by checking if kubeConfig != undefined first. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1101

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
