### PR TITLE
Fix concurrent websocket write issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description of the change

Updates how we start streams + adds locks to websocket send. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Relevant release note information

Release Notes:

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
