### PR TITLE
Bump submodule for port forward fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description of the change

Bumps the bzero submodule for the kube port forward fix

## Relevant release note information

Release Notes: Fixes kube port forward for daemon

## Related JIRA tickets

Relates to JIRA: CWC-1668

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: