### PR TITLE
Hotfix: broken ssh proxy hostname

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "5.6.18",
+  "version": "5.6.19",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/handlers/generate-config/generate-ssh-config.handler.ts
+++ b/src/handlers/generate-config/generate-ssh-config.handler.ts
@@ -21,7 +21,7 @@ export async function generateSshConfigHandler(argv: yargs.Arguments<generateCon
 
     // Build our ssh config file -- note that by using this function with 'true' we are chosing to add the prefix before our hostname token in the proxycommand
     const { identityFile, proxyCommand, prefix } = await buildSshConfigStrings(configService, processName, logger, true);
-    const bzConfigContentsFormatted = formatBzConfigContents(tunnels, identityFile, proxyCommand, prefix);
+    const bzConfigContentsFormatted = formatBzConfigContents(tunnels, identityFile, proxyCommand);
 
     // Determine and write to the user's ssh and bzero-ssh config path
     const { userConfigPath, bzConfigPath } = getFilePaths(argv.mySshPath, argv.bzSshPath, prefix);
@@ -52,10 +52,9 @@ function getFilePaths(userSshPath: string, bzSshPath: string, configPrefix: stri
  * @param tunnels {TunnelsResponse[]} A list of targets the user can access over SSH tunnel
  * @param identityFile {string} A path to the user's key file
  * @param proxyCommand {string} A proxy command routing SSH requests to the ZLI
- * @param prefix {string} a hostname prefix (e.g. bzero, bzero-dev) so that the user doesn't have to worry about it
  * @returns {string} the bz config file contents
  */
-function formatBzConfigContents(tunnels: TunnelsResponse[], identityFile: string, proxyCommand: string, prefix: string): string {
+function formatBzConfigContents(tunnels: TunnelsResponse[], identityFile: string, proxyCommand: string): string {
     let contents = ``;
 
     // add per-target configs

--- a/src/handlers/generate-config/generate-ssh-config.handler.ts
+++ b/src/handlers/generate-config/generate-ssh-config.handler.ts
@@ -19,8 +19,8 @@ export async function generateSshConfigHandler(argv: yargs.Arguments<generateCon
     const policyQueryHttpService = new PolicyQueryHttpService(configService, logger);
     const tunnels: TunnelsResponse[] = await policyQueryHttpService.GetTunnels();
 
-    // Build our ssh config file
-    const { identityFile, proxyCommand, prefix } = await buildSshConfigStrings(configService, processName, logger);
+    // Build our ssh config file -- note that by using this function with 'true' we are chosing to add the prefix before our hostname token in the proxycommand
+    const { identityFile, proxyCommand, prefix } = await buildSshConfigStrings(configService, processName, logger, true);
     const bzConfigContentsFormatted = formatBzConfigContents(tunnels, identityFile, proxyCommand, prefix);
 
     // Determine and write to the user's ssh and bzero-ssh config path
@@ -64,7 +64,6 @@ function formatBzConfigContents(tunnels: TunnelsResponse[], identityFile: string
         const user = tunnel.targetUsers.length === 1 ? `User ${tunnel.targetUsers[0].userName}` : ``;
         contents += `
 Host ${tunnel.targetName}
-    HostName ${prefix}${tunnel.targetName}
     ${identityFile}
     ${proxyCommand}
     ${user}

--- a/src/handlers/generate-config/generate-ssh-config.handler.ts
+++ b/src/handlers/generate-config/generate-ssh-config.handler.ts
@@ -21,7 +21,7 @@ export async function generateSshConfigHandler(argv: yargs.Arguments<generateCon
 
     // Build our ssh config file
     const { identityFile, proxyCommand, prefix } = await buildSshConfigStrings(configService, processName, logger);
-    const bzConfigContentsFormatted = formatBzConfigContents(tunnels, identityFile, proxyCommand);
+    const bzConfigContentsFormatted = formatBzConfigContents(tunnels, identityFile, proxyCommand, prefix);
 
     // Determine and write to the user's ssh and bzero-ssh config path
     const { userConfigPath, bzConfigPath } = getFilePaths(argv.mySshPath, argv.bzSshPath, prefix);
@@ -52,9 +52,10 @@ function getFilePaths(userSshPath: string, bzSshPath: string, configPrefix: stri
  * @param tunnels {TunnelsResponse[]} A list of targets the user can access over SSH tunnel
  * @param identityFile {string} A path to the user's key file
  * @param proxyCommand {string} A proxy command routing SSH requests to the ZLI
+ * @param prefix {string} a hostname prefix (e.g. bzero, bzero-dev) so that the user doesn't have to worry about it
  * @returns {string} the bz config file contents
  */
-function formatBzConfigContents(tunnels: TunnelsResponse[], identityFile: string, proxyCommand: string): string {
+function formatBzConfigContents(tunnels: TunnelsResponse[], identityFile: string, proxyCommand: string, prefix: string): string {
     let contents = ``;
 
     // add per-target configs
@@ -63,6 +64,7 @@ function formatBzConfigContents(tunnels: TunnelsResponse[], identityFile: string
         const user = tunnel.targetUsers.length === 1 ? `User ${tunnel.targetUsers[0].userName}` : ``;
         contents += `
 Host ${tunnel.targetName}
+    HostName ${prefix}${tunnel.targetName}
     ${identityFile}
     ${proxyCommand}
     ${user}

--- a/src/handlers/ssh-proxy-config.handler.ts
+++ b/src/handlers/ssh-proxy-config.handler.ts
@@ -20,7 +20,7 @@ ssh <user>@${prefix}<ssm-target-id-or-name>
 `);
 }
 
-export async function buildSshConfigStrings(configService: ConfigService, processName: string, logger: Logger) {
+export async function buildSshConfigStrings(configService: ConfigService, processName: string, logger: Logger, addProxyPrefix: boolean = false) {
     const keyPath = configService.sshKeyPath();
     const identityFile = `IdentityFile ${keyPath}`;
 
@@ -33,7 +33,7 @@ export async function buildSshConfigStrings(configService: ConfigService, proces
     }
 
     const hostnameToken = await getHostnameToken(logger);
-    const proxyCommand = `ProxyCommand ${processName} ssh-proxy ${configNameArg} -s ${hostnameToken} %r %p ${keyPath}`;
+    const proxyCommand = `ProxyCommand ${processName} ssh-proxy ${configNameArg} -s ${addProxyPrefix ? prefix : ''}${hostnameToken} %r %p ${keyPath}`;
 
     return { identityFile, proxyCommand, prefix };
 }

--- a/src/handlers/ssh-proxy-config.handler.ts
+++ b/src/handlers/ssh-proxy-config.handler.ts
@@ -33,7 +33,7 @@ export async function buildSshConfigStrings(configService: ConfigService, proces
     }
 
     const hostnameToken = await getHostnameToken(logger);
-    const proxyCommand = `ProxyCommand ${processName} ssh-proxy ${configNameArg} -s ${prefix}${hostnameToken} %r %p ${keyPath}`;
+    const proxyCommand = `ProxyCommand ${processName} ssh-proxy ${configNameArg} -s ${hostnameToken} %r %p ${keyPath}`;
 
     return { identityFile, proxyCommand, prefix };
 }


### PR DESCRIPTION
## Description of the change

As part of #329 a regression was introduced where `zli ssh-proxy-config` creates a broken file, where the bzero prefix is wrongly added to the hostname in the proxycommand. We want this behavior for `generate sshConfig` only

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1726

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: