### PR TITLE
Shell connect/attach agent version checks only apply on prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bastionzero/zli",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@jsier/retrier": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/handlers/attach/attach.handler.ts
+++ b/src/handlers/attach/attach.handler.ts
@@ -53,7 +53,7 @@ export async function attachHandler(
         // TODO: Adjust this version check once pipelining changes are in and we support attaching
         // agentVersion will be null if this isn't a valid version (i.e if its "$AGENT_VERSION" string during development)
         const agentVersion = parse(bzeroTarget.agentVersion);
-        if(agentVersion) {
+        if(configService.getConfigName() == 'prod' && agentVersion) {
             logger.error(`Attaching to a Bzero Target is not yet supported.`);
             return 1;
         }

--- a/src/handlers/connect/shell-connect.handler.ts
+++ b/src/handlers/connect/shell-connect.handler.ts
@@ -105,7 +105,7 @@ export async function shellConnectHandler(
 
         // agentVersion will be null if this isn't a valid version (i.e if its "$AGENT_VERSION" string during development)
         const agentVersion = parse(bzeroTarget.agentVersion);
-        if(agentVersion && lt(agentVersion, new SemVer('5.0.0'))) {
+        if(configService.getConfigName() == 'prod' && agentVersion && lt(agentVersion, new SemVer('5.0.0'))) {
             logger.error(`Connecting to Bzero Target is only supported on agent versions >= 5.0.0. Agent version is ${agentVersion}`);
             return 1;
         }


### PR DESCRIPTION
## Description of the change

Only check agent version when running against prod so we can test out `-beta` releases of the agent on staging.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: