### PR TITLE
Update system test codebuild spec to use goenv

### DIFF
--- a/Codebuild/system-test-codebuild.yaml
+++ b/Codebuild/system-test-codebuild.yaml
@@ -40,11 +40,10 @@ phases:
       - pip3 install -e /cwc-infra/Bzero-Common/. && pip3 install -e /cwc-infra/Bzero-QA/.
       # Install npm dependencies
       - apt-get update -y && apt-get install build-essential cmake -y
-      # We need to 1.16 and this isnt in yum
-      - wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz -q
-      - tar -C /usr/local -xzf go1.16.4.linux-amd64.tar.gz
-      - echo 'export PATH=/usr/local/go/bin:$PATH' >>~/.bash_profile
-      - export PATH=/usr/local/go/bin:$PATH
+      # We need 1.16 and this isn't in apt-get
+      # Codebuild images use `goenv` to manage `go` versions
+      # Source: https://github.com/aws/aws-codebuild-docker-images/issues/425
+      - goenv local 1.16.4
       # Update npm 
       - npm install -g npm@8
       - # Install system-test dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.3.20",
+  "version": "6.3.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bastionzero/zli",
-      "version": "6.3.20",
+      "version": "6.3.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@jsier/retrier": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.3.20",
+  "version": "6.3.21",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description of the change

Updates codebuild spec file to use `goenv` when installing `go`

## Testing

Describe how to test this PR....

**backend branch:** 
**bzero branch:** 

#### Ready to run system tests?

- [x] Yes

## Relevant release note information

Release Notes: Updates codebuild spec file to use goenv when installing go

## Related JIRA tickets

Relates to JIRA: CWC-1893

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: