### PR TITLE
Use npm v8 in webshell-cli-release codebuild spec

### DIFF
--- a/webshell-cli-release.yml
+++ b/webshell-cli-release.yml
@@ -15,6 +15,8 @@ phases:
     commands:
       - echo Install started `date`
       - apt-get update -y && apt-get install build-essential cmake -y
+      # Update npm to v8
+      - npm install -g npm@8
       - npm ci
   pre_build:
     commands:


### PR DESCRIPTION
## Description of the change

Fix webshell-cli-release to use npm v8 as well. Required as on #427 

## Testing

Describe how to test this PR....

**backend branch:** 
**bzero branch:** 

#### Ready to run system tests?

- [x] Yes

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1967

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: