### PR TITLE
Agent Recovery Suite

### DIFF
--- a/Codebuild/system-test-codebuild.yaml
+++ b/Codebuild/system-test-codebuild.yaml
@@ -36,7 +36,7 @@ phases:
       - git submodule init
       - git submodule update --recursive
       # Install Bzero-QA
-      - git clone git@github.com:bastionzero/cwc-infra.git  --branch develop /cwc-infra/
+      - git clone git@github.com:bastionzero/cwc-infra.git --branch $CWC_INFRA_BRANCH /cwc-infra/
       - pip3 install -e /cwc-infra/Bzero-Common/. && pip3 install -e /cwc-infra/Bzero-QA/.
       # Install npm dependencies
       - apt-get update -y && apt-get install build-essential cmake -y

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/http-services/events/events.http-server.ts
+++ b/src/http-services/events/events.http-server.ts
@@ -5,6 +5,7 @@ import { ConnectionEventDataMessage } from '../../../webshell-common-ts/http/v2/
 import { CommandEventDataMessage } from '../../../webshell-common-ts/http/v2/event/types/command-event-data-message';
 import { KubeEventDataMessage } from '../../../webshell-common-ts/http/v2/event/types/kube-event-data-message.types';
 import { UserEventDataMessage } from '../../../webshell-common-ts/http/v2/event/types/user-event-data-message.types';
+import { TargetType } from '../../../webshell-common-ts/http/v2/target/types/target.types';
 
 
 export class EventsHttpService extends HttpService
@@ -50,5 +51,13 @@ export class EventsHttpService extends HttpService
             eventCount: count?.toString()
         };
         return this.Get('user', params);
+    }
+
+    public GetAgentStatusChangeEvents(targetId: string, targetType: TargetType) {
+        const params = {
+            targetId,
+            targetType,
+        };
+        return this.Get('agentstatuschange', params);
     }
 }

--- a/src/http-services/events/events.http-server.ts
+++ b/src/http-services/events/events.http-server.ts
@@ -53,7 +53,7 @@ export class EventsHttpService extends HttpService
         return this.Get('user', params);
     }
 
-    public GetAgentStatusChangeEvents(targetId: string, startTime?: Date, endTime?: Date): Promise<AgentStatusChangeData> {
+    public GetAgentStatusChangeEvents(targetId: string, startTime?: Date, endTime?: Date): Promise<AgentStatusChangeData[]> {
         const params = {
             targetId: targetId,
             startTimestamp: startTime?.toJSON(),

--- a/src/http-services/events/events.http-server.ts
+++ b/src/http-services/events/events.http-server.ts
@@ -5,7 +5,7 @@ import { ConnectionEventDataMessage } from '../../../webshell-common-ts/http/v2/
 import { CommandEventDataMessage } from '../../../webshell-common-ts/http/v2/event/types/command-event-data-message';
 import { KubeEventDataMessage } from '../../../webshell-common-ts/http/v2/event/types/kube-event-data-message.types';
 import { UserEventDataMessage } from '../../../webshell-common-ts/http/v2/event/types/user-event-data-message.types';
-import { TargetType } from '../../../webshell-common-ts/http/v2/target/types/target.types';
+import { AgentStatusChangeData } from '../../../webshell-common-ts/http/v2/event/types/agent-status-change-data.types';
 
 
 export class EventsHttpService extends HttpService
@@ -53,11 +53,13 @@ export class EventsHttpService extends HttpService
         return this.Get('user', params);
     }
 
-    public GetAgentStatusChangeEvents(targetId: string, targetType: TargetType) {
+    public GetAgentStatusChangeEvents(targetId: string, startTime?: Date, endTime?: Date): Promise<AgentStatusChangeData> {
         const params = {
-            targetId,
-            targetType,
+            targetId: targetId,
+            startTime: startTime?.toJSON(),
+            endTime: endTime?.toJSON(),
         };
+
         return this.Get('agentstatuschange', params);
     }
 }

--- a/src/http-services/events/events.http-server.ts
+++ b/src/http-services/events/events.http-server.ts
@@ -56,8 +56,8 @@ export class EventsHttpService extends HttpService
     public GetAgentStatusChangeEvents(targetId: string, startTime?: Date, endTime?: Date): Promise<AgentStatusChangeData> {
         const params = {
             targetId: targetId,
-            startTime: startTime?.toJSON(),
-            endTime: endTime?.toJSON(),
+            startTimestamp: startTime?.toJSON(),
+            endTimestamp: endTime?.toJSON(),
         };
 
         return this.Get('agentstatuschange', params);

--- a/src/system-tests/tests/suites/agent-recovery.ts
+++ b/src/system-tests/tests/suites/agent-recovery.ts
@@ -15,7 +15,7 @@ import { Environment } from '../../../../webshell-common-ts/http/v2/policy/types
 import { VerbType } from '../../../../webshell-common-ts/http/v2/policy/types/verb-type.types';
 
 export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerUniqueId: string) => {
-    describe('agent recovery suite', () => {
+    describe('Agent Recovery Suite', () => {
         let k8sApi: k8s.CoreV1Api;
         let k8sExec: k8s.Exec;
         let policyService: PolicyHttpService;
@@ -65,8 +65,7 @@ export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerU
         });
 
         bzeroTestTargetsToRun.forEach(async (testTarget) => {
-            const caseIdPlaceholder = 'xyz';
-            it(`${caseIdPlaceholder}: bastion restart ${testTarget.awsRegion} - ${getDOImageName(testTarget.dropletImage)}`, async () => {
+            it(`247517: bastion restart ${testTarget.awsRegion} - ${getDOImageName(testTarget.dropletImage)}`, async () => {
                 const testStartTime = new Date();
                 const doTarget = testTargets.get(testTarget);
                 const connectTarget = connectTestUtils.getConnectTarget(doTarget, testTarget.awsRegion);
@@ -117,9 +116,6 @@ export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerU
                 logger.info('Found offline to online event');
 
                 await connectTestUtils.runShellConnectTest(testTarget, `bastion restart test - ${systemTestUniqueId}`, true);
-
-                logger.info('ran connect test successfully');
-
             },
             10 * 60 * 1000); // 10 min timeout
         });

--- a/src/system-tests/tests/suites/agent-recovery.ts
+++ b/src/system-tests/tests/suites/agent-recovery.ts
@@ -82,7 +82,7 @@ export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerU
         });
 
         bzeroTestTargetsToRun.forEach(async (testTarget) => {
-            it(`${fromTestTargetToCaseIdMapping(testTarget)}: bastion restart ${testTarget.awsRegion} - ${getDOImageName(testTarget.dropletImage)}`, async () => {
+            it(`${fromTestTargetToCaseIdMapping(testTarget).agentRecoveryBastionRestart}: bastion restart ${testTarget.awsRegion} - ${getDOImageName(testTarget.dropletImage)}`, async () => {
                 const doTarget = testTargets.get(testTarget);
                 const connectTarget = connectTestUtils.getConnectTarget(doTarget, testTarget.awsRegion);
 

--- a/src/system-tests/tests/suites/agent-recovery.ts
+++ b/src/system-tests/tests/suites/agent-recovery.ts
@@ -1,19 +1,23 @@
 import * as k8s from '@kubernetes/client-node';
 
-import { configService, logger, loggerConfigService, systemTestEnvId, systemTestPolicyTemplate, systemTestUniqueId, testTargets } from '../system-test';
+import { configService, logger, loggerConfigService, systemTestEnvId, systemTestPolicyTemplate, systemTestUniqueId, testCluster, testTargets } from '../system-test';
 import { ConnectionHttpService } from '../../../http-services/connection/connection.http-services';
 import { DigitalOceanDistroImage, getDOImageName } from '../../digital-ocean/digital-ocean-ssm-target.service.types';
 import { sleepTimeout, TestUtils } from '../utils/test-utils';
-import { ConnectTestUtils } from '../utils/connect-utils';
+import { ConnectTestUtils, setupBackgroundDaemonMocks } from '../utils/connect-utils';
 import { bzeroTestTargetsToRun } from '../targets-to-run';
-import { execOnPod } from '../../../utils/kube-utils';
-import { getPodWithLabelSelector } from '../../../utils/kube-utils';
+import { execOnPod } from '../utils/kube-utils';
+import { getPodWithLabelSelector } from '../utils/kube-utils';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 import { Subject } from '../../../../webshell-common-ts/http/v2/policy/types/subject.types';
 import { SubjectType } from '../../../../webshell-common-ts/http/v2/common.types/subject.types';
 import { Environment } from '../../../../webshell-common-ts/http/v2/policy/types/environment.types';
 import { VerbType } from '../../../../webshell-common-ts/http/v2/policy/types/verb-type.types';
 import { TestTarget } from '../system-test.types';
+import { callZli } from '../utils/zli-utils';
+import { KubeTestUserName } from './kube';
+
+const kubeConfigYamlFilePath = `/tmp/bzero-agent-kubeconfig-${systemTestUniqueId}.yml`;
 
 // Create mapping object and function for test rails case IDs
 interface testRailsCaseIdMapping {
@@ -73,12 +77,16 @@ export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerU
                 targetUsers: ConnectTestUtils.getPolicyTargetUsers(),
                 verbs: [{type: VerbType.Shell},]
             });
+
+            // Generate kube yaml to use for kube agent restart test
+            await callZli(['generate', 'kubeConfig', '-o', kubeConfigYamlFilePath]);
         });
 
         // Called before each case
         beforeEach(() => {
             testStartTime = new Date();
             connectTestUtils = new ConnectTestUtils(connectionService, testUtils);
+            setupBackgroundDaemonMocks();
         });
 
         bzeroTestTargetsToRun.forEach(async (testTarget) => {
@@ -86,66 +94,93 @@ export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerU
                 const doTarget = testTargets.get(testTarget);
                 const connectTarget = connectTestUtils.getConnectTarget(doTarget, testTarget.awsRegion);
 
-                const bastionPod = await getBastionPod(k8sApi, testRunnerUniqueId);
-                const bastionContainer = 'bastion';
+                await restartBastionAndWaitForAgentToReconnect(connectTarget.id);
 
-                // Stop the systemd service on the bastion container to simulate bastion going down temporarily
-                logger.info('stopping bastion container');
-
-                // In practice both the SIGKILL and the stop commands still
-                // result in agent going offline because of
-                // control-channel-disconnect- so the websocket is still closing
-                // normally and updating the status in the database. The harsh
-                // command is probably not working as intended because it only
-                // kills the start.sh script which calls dotnet run but not the
-                // actual Webshell.WebApp process itself.
-
-                // With CC -> CN changes we can instead refactor this to
-                // simulate a failure of the connection node pod by deleting the
-                // pod that contains the control channel and the offline event
-                // should happen immediately on bastion
-
-                // send a SIGKILL signal to simulate the bastion crashing
-                // instead of gracefully shutting down
-                // https://serverfault.com/questions/936037/killing-systemd-service-with-and-without-systemctl
-                // const harshStopCommand = ['/usr/local/bin/systemctl', 'kill', '-s', 'SIGKILL', 'bzero-server'];
-                const gracefulStopCommand = ['/usr/local/bin/systemctl', 'stop', 'bzero-server'];
-
-                await execOnPod(k8sExec, bastionPod, bastionContainer, gracefulStopCommand, logger);
-
-                // Wait for 1 min before restarting bastion
-                logger.info('waiting 1 min before restarting bastion');
-                await sleepTimeout(1 * 60 * 1000);
-
-                // Start the systemd service on the bastion container
-                logger.info('starting bastion container');
-                const startCommand = ['/usr/local/bin/systemctl', 'start', 'bzero-server'];
-                await execOnPod(k8sExec, bastionPod, bastionContainer, startCommand, logger);
-
-                // Once bastion comes back online we should be able to query and
-                // find a online->offline event for this agent
-                await testUtils.EnsureAgentStatusEvent(connectTarget.id, {
-                    statusChange: 'OnlineToOffline'
-                }, testStartTime, undefined, 2 * 60 * 1000);
-
-                logger.info('Found online to offline event');
-
-                // Then the agent should try and reconnect its control channel
-                // websocket to bastion which will move the agent back to
-                // online. We use a longer timeout here because while the
-                // bastion is down the agent goes into a reconnect loop with
-                // exponential backoff that will cause it to wait longer before
-                // reconnecting
-                await testUtils.EnsureAgentStatusEvent(connectTarget.id, {
-                    statusChange: 'OfflineToOnline',
-                }, testStartTime, undefined, 5 * 60 * 1000);
-
-                logger.info('Found offline to online event');
-
+                // Run normal shell connect test to ensure that still works after reconnecting
                 await connectTestUtils.runShellConnectTest(testTarget, `bastion restart test - ${systemTestUniqueId}`, true);
             },
             10 * 60 * 1000); // 10 min timeout
         });
+
+        it('252823: kube agent bastion restart test', async() => {
+            // Start the kube daemon
+            await callZli(['connect', `${KubeTestUserName}@${testCluster.bzeroClusterTargetSummary.name}`, '--targetGroup', 'system:masters']);
+
+            await restartBastionAndWaitForAgentToReconnect(testCluster.bzeroClusterTargetSummary.id);
+
+            // Attempt a simple listNamespace kubectl test after reconnecting
+            const bzkc = new k8s.KubeConfig();
+            bzkc.loadFromFile(kubeConfigYamlFilePath);
+            const bzk8sApi = bzkc.makeApiClient(k8s.CoreV1Api);
+
+            const listNamespaceResp = await bzk8sApi.listNamespace();
+            const resp = listNamespaceResp.body;
+            expect(resp.items.find(t => t.metadata.name === testCluster.helmChartNamespace)).toBeTruthy();
+
+            await callZli(['disconnect', 'kube']);
+        }, 10 * 60 * 1000); // 10 min timeout;
+
+        /**
+         * Restarts bastion pod and then waits for agent online->offline and then offline->online events
+         * @param targetId The targetId of the agent we are testing
+         */
+        async function restartBastionAndWaitForAgentToReconnect(targetId: string) {
+            const bastionPod = await getBastionPod(k8sApi, testRunnerUniqueId);
+            const bastionContainer = 'bastion';
+
+            // Stop the systemd service on the bastion container to simulate bastion going down temporarily
+            logger.info('stopping bastion container');
+
+            // In practice both the SIGKILL and the stop commands still
+            // result in agent going offline because of
+            // control-channel-disconnect- so the websocket is still closing
+            // normally and updating the status in the database. The harsh
+            // command is probably not working as intended because it only
+            // kills the start.sh script which calls dotnet run but not the
+            // actual Webshell.WebApp process itself.
+
+            // With CC -> CN changes we can instead refactor this to
+            // simulate a failure of the connection node pod by deleting the
+            // pod that contains the control channel and the offline event
+            // should happen immediately on bastion
+
+            // send a SIGKILL signal to simulate the bastion crashing
+            // instead of gracefully shutting down
+            // https://serverfault.com/questions/936037/killing-systemd-service-with-and-without-systemctl
+            // const harshStopCommand = ['/usr/local/bin/systemctl', 'kill', '-s', 'SIGKILL', 'bzero-server'];
+            const gracefulStopCommand = ['/usr/local/bin/systemctl', 'stop', 'bzero-server'];
+
+            await execOnPod(k8sExec, bastionPod, bastionContainer, gracefulStopCommand, logger);
+
+            // Wait for 1 min before restarting bastion
+            logger.info('waiting 1 min before restarting bastion');
+            await sleepTimeout(1 * 60 * 1000);
+
+            // Start the systemd service on the bastion container
+            logger.info('starting bastion container');
+            const startCommand = ['/usr/local/bin/systemctl', 'start', 'bzero-server'];
+            await execOnPod(k8sExec, bastionPod, bastionContainer, startCommand, logger);
+
+            // Once bastion comes back online we should be able to query and
+            // find a online->offline event for this agent
+            await testUtils.EnsureAgentStatusEvent(targetId, {
+                statusChange: 'OnlineToOffline'
+            }, testStartTime, undefined, 2 * 60 * 1000);
+
+            logger.info('Found online to offline event');
+
+            // Then the agent should try and reconnect its control channel
+            // websocket to bastion which will move the agent back to
+            // online. We use a longer timeout here because while the
+            // bastion is down the agent goes into a reconnect loop with
+            // exponential backoff that will cause it to wait longer before
+            // reconnecting
+            await testUtils.EnsureAgentStatusEvent(targetId, {
+                statusChange: 'OfflineToOnline',
+            }, testStartTime, undefined, 5 * 60 * 1000);
+
+            logger.info('Found offline to online event');
+        }
 
         async function getBastionPod(k8sApi: k8s.CoreV1Api, uniqueId: string) {
             const resp = await getPodWithLabelSelector(k8sApi, 'default', { 'uniqueId': uniqueId, 'podType': 'bastion'});

--- a/src/system-tests/tests/suites/agent-recovery.ts
+++ b/src/system-tests/tests/suites/agent-recovery.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import * as k8s from '@kubernetes/client-node';
+
+import { configService, logger, loggerConfigService, systemTestUniqueId, testTargets } from '../system-test';
+import { ConnectionHttpService } from '../../../http-services/connection/connection.http-services';
+import { getDOImageName } from '../../digital-ocean/digital-ocean-ssm-target.service.types';
+import { sleepTimeout, TestUtils } from '../utils/test-utils';
+import { ConnectTestUtils } from '../utils/connect-utils';
+import { bzeroTestTargetsToRun } from '../targets-to-run';
+import { execOnPod } from '../../../utils/kube-utils';
+import { getPodWithLabelSelector } from '../../../utils/kube-utils';
+
+export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerUniqueId: string) => {
+    describe('agent recovery suite', () => {
+        let k8sApi: k8s.CoreV1Api;
+        let k8sExec: k8s.Exec;
+        let testUtils: TestUtils;
+        let connectionService: ConnectionHttpService;
+        let connectTestUtils: ConnectTestUtils;
+
+        beforeAll(async () => {
+            testUtils = new TestUtils(configService, logger, loggerConfigService);
+            connectionService = new ConnectionHttpService(configService, logger);
+
+            // const kubeConfigFileContent = fs.readFileSync(testRunnerKubeConfigFile).toString();
+            // logger.info(`Test runner kube config file is ${testRunnerKubeConfigFile} with contents: ${kubeConfigFileContent}`);
+            logger.info(`Test runner uniqueId is: ${testRunnerUniqueId}`);
+            
+            // Setup the kube client from the test runner configuration
+            const kc = new k8s.KubeConfig();
+            kc.loadFromFile(testRunnerKubeConfigFile);
+            k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+            k8sExec = new k8s.Exec(kc);
+        });
+
+        // Called before each case
+        beforeEach(() => {
+            connectTestUtils = new ConnectTestUtils(connectionService, testUtils);
+        });
+
+        bzeroTestTargetsToRun.forEach(async (testTarget) => {
+            const caseIdPlaceholder = 'xyz';
+            it(`${caseIdPlaceholder}: bastion restart ${testTarget.awsRegion} - ${getDOImageName(testTarget.dropletImage)}`, async () => {
+                const testStartTime = new Date();
+                const doTarget = testTargets.get(testTarget);
+                const connectTarget = connectTestUtils.getConnectTarget(doTarget, testTarget.awsRegion);
+
+                // Note: with CC -> CN changes we can instead refactor this to
+                // simulate a failure of the connection node pod that contains
+                // the control channel and the offline event should happen
+                // immediately on bastion
+
+                let bastionPod = await getBastionPod(k8sApi, testRunnerUniqueId);
+                const bastionContainer = 'bastion';
+                
+                // Stop the systemd service on the bastion container to simulate bastion going down temporarily
+                logger.info("stopping bastion container");
+                const stopCommand = ['/usr/local/bin/systemctl', 'stop', 'bzero-server'];
+                await execOnPod(k8sExec, bastionPod, bastionContainer, stopCommand, logger);
+    
+                // Wait for 2 min to ensure when we start bastion again the
+                // heartbeat poller will move the agent to offline status
+                logger.info("waiting 2 min before restarting bastion");
+                await sleepTimeout(2 * 60 * 1000);
+                
+                // Start the systemd service on the bastion container
+                logger.info("starting bastion container");
+                const startCommand = ['/usr/local/bin/systemctl', 'start', 'bzero-server'];
+                await execOnPod(k8sExec, bastionPod, bastionContainer, startCommand, logger);
+                
+                // Once bastion comes back online the agent status should
+                // immediately move to offline because its been > 2 min since
+                // last heartbeat
+                await testUtils.EnsureAgentStatusEvent(connectTarget.id, {
+                    statusChange: "OnlineToOffline"
+                }, 2 * 60 * 1000);
+
+                logger.info("Found online to offline event");
+
+                // Then the agent should try and reconnect its control channel
+                // websocket to bastion which will move the agent back to online 
+                await testUtils.EnsureAgentStatusEvent(connectTarget.id, {
+                    statusChange: "OfflineToOnline",
+                    // TODO: fix this to filter by start time
+                    timeStamp: expect.toBeAfter(testStartTime)
+                }, 2 * 60 * 1000);
+
+                logger.info("Found offline to online event");
+
+                await connectTestUtils.runShellConnectTest(testTarget, `bastion restart test - ${systemTestUniqueId}`, true);
+
+                logger.info("ran connect test");
+                
+            },
+            10 * 60 * 1000); // 10 min timeout
+        });
+
+        async function getBastionPod(k8sApi: k8s.CoreV1Api, uniqueId: string) {
+            const resp = await getPodWithLabelSelector(k8sApi, 'default', { 'uniqueId': uniqueId, 'podType': 'bastion'});
+
+            const podCount = resp.body.items.length;
+            if(podCount != 1) {
+                throw new Error(`Found ${podCount} bastion pods.`);
+            }
+
+            return resp.body.items[0];
+        }
+
+        async function getConnectionNodePods(k8sApi: k8s.CoreV1Api, uniqueId: string) {
+            return getPodWithLabelSelector(k8sApi, 'connection-service', { 'uniqueId': uniqueId, 'podType': 'connection-node'});
+        }
+    });
+}

--- a/src/system-tests/tests/suites/agent-recovery.ts
+++ b/src/system-tests/tests/suites/agent-recovery.ts
@@ -88,7 +88,7 @@ export const agentRecoverySuite = (testRunnerKubeConfigFile: string, testRunnerU
                 // simulate a failure of the connection node pod by deleting the
                 // pod that contains the control channel and the offline event
                 // should happen immediately on bastion
-                
+
                 // send a SIGKILL signal to simulate the bastion crashing
                 // instead of gracefully shutting down
                 // https://serverfault.com/questions/936037/killing-systemd-service-with-and-without-systemctl

--- a/src/system-tests/tests/suites/connect.ts
+++ b/src/system-tests/tests/suites/connect.ts
@@ -25,6 +25,7 @@ export const connectSuite = () => {
         let connectTestUtils: ConnectTestUtils;
         let testPassed = false;
         let userLogFilterStartTime: Date;
+        let testStartTime: Date;
 
         // Set up the policy before all the tests
         beforeAll(async () => {
@@ -66,6 +67,7 @@ export const connectSuite = () => {
 
         // Called before each case
         beforeEach(() => {
+            testStartTime = new Date();
             connectTestUtils = new ConnectTestUtils(connectionService, testUtils);
         });
 
@@ -109,7 +111,7 @@ export const connectSuite = () => {
                 const attachPromise = callZli(['attach', connectionId]);
 
                 // After attaching we should see another client connection event
-                await connectTestUtils.ensureConnectionEvent(attachTarget, ConnectionEventType.ClientConnect);
+                await connectTestUtils.ensureConnectionEvent(attachTarget, ConnectionEventType.ClientConnect, testStartTime);
                 const eventExists = await testUtils.EnsureUserEventExists('connectionservice:connect', true, attachTarget.id, new Date(userLogFilterStartTime));
                 expect(eventExists).toBeTrue();
 
@@ -138,7 +140,7 @@ export const connectSuite = () => {
                 await attachPromise;
 
                 // After exiting we should see a client disconnected event
-                await connectTestUtils.ensureConnectionEvent(attachTarget, ConnectionEventType.ClientDisconnect);
+                await connectTestUtils.ensureConnectionEvent(attachTarget, ConnectionEventType.ClientDisconnect, testStartTime);
 
                 testPassed = true;
             }, 4 * 60 * 1000); // Use a longer timeout on attach tests because they essentially run 2 back-to-back connect tests
@@ -165,7 +167,7 @@ export const connectSuite = () => {
                 );
 
                 // Expect our close event now
-                await connectTestUtils.ensureConnectionEvent(connectTarget, ConnectionEventType.Closed);
+                await connectTestUtils.ensureConnectionEvent(connectTarget, ConnectionEventType.Closed, testStartTime);
 
                 testPassed = true;
             }, 2 * 60 * 1000);

--- a/src/system-tests/tests/suites/db.ts
+++ b/src/system-tests/tests/suites/db.ts
@@ -100,6 +100,7 @@ export const dbSuite = () => {
         let policyService: PolicyHttpService;
         let dbDaemonManagementService: DaemonManagementService<DbConfig>;
         let testUtils: TestUtils;
+        let testStartTime: Date;
 
         // Proxy policy ID created for this entire suite in order to make DB
         // connections
@@ -144,6 +145,7 @@ export const dbSuite = () => {
         }, 60 * 1000);
 
         beforeEach(() => {
+            testStartTime = new Date();
             // Reset tracked state of created db targets
             createdDbTargets = [];
             setupBackgroundDaemonMocks();
@@ -242,7 +244,7 @@ export const dbSuite = () => {
                     environmentName: systemTestEnvName,
                     connectionEventType: eventType,
                     connectionId: daemon.connectionId
-                });
+                }, testStartTime);
             };
 
             /**

--- a/src/system-tests/tests/suites/dynamic-access.ts
+++ b/src/system-tests/tests/suites/dynamic-access.ts
@@ -97,7 +97,7 @@ export const dynamicAccessSuite = () => {
 
             // Delete the DAT target
             await dynamicAccessConfigService.DeleteDynamicAccessConfig(dynamicAccessId);
-        });
+        }, 60 * 1000);
 
         test(`3090: Connect to DAT target`, async () => {
             const exit = true;

--- a/src/system-tests/tests/suites/groups.ts
+++ b/src/system-tests/tests/suites/groups.ts
@@ -56,7 +56,7 @@ export const groupsSuite = () => {
         afterAll(async () => {
             // Search and delete our target connect policy
             await cleanupTargetConnectPolicies(systemTestPolicyTemplate.replace('$POLICY_TYPE', 'group-connect'));
-        });
+        }, 60 * 1000);
 
         // Called before each case
         beforeEach(() => {

--- a/src/system-tests/tests/suites/kube.ts
+++ b/src/system-tests/tests/suites/kube.ts
@@ -21,6 +21,7 @@ export const kubeSuite = () => {
     describe('kube suite', () => {
         let policyService: PolicyHttpService;
         let testUtils: TestUtils;
+        let testStartTime: Date;
 
         let testPassed = false;
         const kubeConfigYamlFilePath = `/tmp/bzero-agent-kubeconfig-${systemTestUniqueId}.yml`;
@@ -32,6 +33,7 @@ export const kubeSuite = () => {
         });
 
         beforeEach(() => {
+            testStartTime = new Date();
             setupBackgroundDaemonMocks();
         });
 
@@ -68,7 +70,7 @@ export const kubeSuite = () => {
                 environmentId: testCluster.bzeroClusterTargetSummary.environmentId,
                 environmentName: systemTestEnvNameCluster,
                 connectionEventType: eventType
-            });
+            }, testStartTime);
         };
 
         test('2159: zli generate kubeConfig', async () => {

--- a/src/system-tests/tests/suites/web.ts
+++ b/src/system-tests/tests/suites/web.ts
@@ -24,8 +24,8 @@ export const webSuite = () => {
     describe('web suite', () => {
         let policyService: PolicyHttpService;
         let testUtils: TestUtils;
-
         let testPassed = false;
+        let testStartTime: Date;
 
         // Proxy policy ID created for this entire suite in order to make Web
         // connections
@@ -62,6 +62,7 @@ export const webSuite = () => {
         }, 60 * 1000);
 
         beforeEach(() => {
+            testStartTime = new Date();
             setupBackgroundDaemonMocks();
         });
 
@@ -125,7 +126,7 @@ export const webSuite = () => {
                         environmentId: webTargetSummary.environmentId,
                         environmentName: systemTestEnvName,
                         connectionEventType: eventType
-                    });
+                    }, testStartTime);
                 };
 
                 // Ensure the created and connected event exist

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -1,9 +1,9 @@
 // TODO: Remove this once we determine the cause of the leaky handlers
-// require('leaked-handles').set({
-//     fullStack: true, // use full stack traces
-//     timeout: 30000, // run every 30 seconds instead of 5.
-//     debugSockets: true // pretty print tcp thrown exceptions.
-// });
+require('leaked-handles').set({
+    fullStack: true, // use full stack traces
+    timeout: 30000, // run every 30 seconds instead of 5.
+    debugSockets: true // pretty print tcp thrown exceptions.
+});
 
 import { envMap } from '../../cli-driver';
 import { DigitalOceanBZeroTarget, DigitalOceanSSMTarget } from '../digital-ocean/digital-ocean-ssm-target.service.types';

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -45,6 +45,10 @@ import { eventsRestApiSuite } from './suites/rest-api/events';
 import { webSuite } from './suites/web';
 import { dbSuite } from './suites/db';
 import { agentRecoverySuite } from './suites/agent-recovery';
+import { connectSuite } from './suites/connect';
+import { sessionRecordingSuite } from './suites/session-recording';
+import { sshSuite } from './suites/ssh';
+import { dynamicAccessSuite } from './suites/dynamic-access';
 
 // Uses config name from ZLI_CONFIG_NAME environment variable (defaults to prod
 // if unset) This can be run against dev/stage/prod when running system tests
@@ -283,9 +287,9 @@ if (SSM_ENABLED || BZERO_ENABLED || KUBE_ENABLED) {
 // These suites are based on testing allTargets use SSM_ENABLED or BZERO_ENABLED
 // environment variables to control which targets are created
 if(SSM_ENABLED || BZERO_ENABLED) {
-    // connectSuite();
-    // sessionRecordingSuite();
-    // sshSuite();
+    connectSuite();
+    sessionRecordingSuite();
+    sshSuite();
 
     if (IN_CI && NOT_USING_RUNNER) {
         // Only run group tests if we are in CI and talking to staging or dev
@@ -295,7 +299,7 @@ if(SSM_ENABLED || BZERO_ENABLED) {
 
 // BZero only test suites
 if(BZERO_ENABLED) {
-    // dynamicAccessSuite();
+    dynamicAccessSuite();
 }
 
 // Only run the agent container suite when we are running

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -48,6 +48,7 @@ import { mfaSuite } from './suites/rest-api/mfa';
 import { eventsRestApiSuite } from './suites/rest-api/events';
 import { webSuite } from './suites/web';
 import { dbSuite } from './suites/db';
+import { agentRecoverySuite } from './suites/agent-recovery'
 
 // Uses config name from ZLI_CONFIG_NAME environment variable (defaults to prod
 // if unset) This can be run against dev/stage/prod when running system tests
@@ -306,11 +307,6 @@ if(IN_PIPELINE) {
     agentContainerSuite();
 }
 
-// BZero only test suites
-if(BZERO_ENABLED) {
-    dynamicAccessSuite();
-}
-
 if(KUBE_ENABLED) {
     kubeSuite();
 }
@@ -357,6 +353,13 @@ if (API_ENABLED) {
     } else {
         logger.info('Skipping kube cluster REST API suite because kube cluster creation is disabled.');
     }
+}
+
+if (process.env.TEST_RUNNER_KUBE_CONFIG) {
+    logger.info("Running agent recovery tests");
+    agentRecoverySuite(process.env.TEST_RUNNER_KUBE_CONFIG, process.env.TEST_RUNNER_UNIQUE_ID);
+} else {
+    logger.info('Skipping agent recovery tests because we are not running against a test runner.');
 }
 
 // Always run the version suite

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -1,9 +1,9 @@
 // TODO: Remove this once we determine the cause of the leaky handlers
-require('leaked-handles').set({
-    fullStack: true, // use full stack traces
-    timeout: 30000, // run every 30 seconds instead of 5.
-    debugSockets: true // pretty print tcp thrown exceptions.
-});
+// require('leaked-handles').set({
+//     fullStack: true, // use full stack traces
+//     timeout: 30000, // run every 30 seconds instead of 5.
+//     debugSockets: true // pretty print tcp thrown exceptions.
+// });
 
 import { envMap } from '../../cli-driver';
 import { DigitalOceanBZeroTarget, DigitalOceanSSMTarget } from '../digital-ocean/digital-ocean-ssm-target.service.types';
@@ -12,8 +12,6 @@ import { Logger } from '../../services/logger/logger.service';
 import { ConfigService } from '../../services/config/config.service';
 import { OAuthService } from '../../services/oauth/oauth.service';
 import { randomAlphaNumericString } from '../../utils/utils';
-import { connectSuite } from './suites/connect';
-import { sshSuite } from './suites/ssh';
 import { listTargetsSuite } from './suites/list-targets';
 import { versionSuite } from './suites/version';
 import { RegisteredDigitalOceanKubernetesCluster } from '../digital-ocean/digital-ocean-kube.service.types';
@@ -31,7 +29,6 @@ import { organizationSuite } from './suites/rest-api/organization';
 import { environmentsSuite } from './suites/rest-api/environments';
 import { policySuite } from './suites/rest-api/policies/policies';
 import { groupsSuite } from './suites/groups';
-import { sessionRecordingSuite } from './suites/session-recording';
 import { callZli, mockCleanExit } from './utils/zli-utils';
 import { UserHttpService } from '../../http-services/user/user.http-services';
 import { ssmTargetRestApiSuite } from './suites/rest-api/ssm-targets';
@@ -41,14 +38,13 @@ import { databaseTargetRestApiSuite } from './suites/rest-api/database-targets';
 import { webTargetRestApiSuite } from './suites/rest-api/web-targets';
 import { dynamicAccessConfigRestApiSuite } from './suites/rest-api/dynamic-access-configs';
 import { agentContainerSuite } from './suites/agent-container';
-import { dynamicAccessSuite } from './suites/dynamic-access';
 import { userRestApiSuite } from './suites/rest-api/users';
 import { spacesRestApiSuite } from './suites/rest-api/spaces';
 import { mfaSuite } from './suites/rest-api/mfa';
 import { eventsRestApiSuite } from './suites/rest-api/events';
 import { webSuite } from './suites/web';
 import { dbSuite } from './suites/db';
-import { agentRecoverySuite } from './suites/agent-recovery'
+import { agentRecoverySuite } from './suites/agent-recovery';
 
 // Uses config name from ZLI_CONFIG_NAME environment variable (defaults to prod
 // if unset) This can be run against dev/stage/prod when running system tests
@@ -287,9 +283,9 @@ if (SSM_ENABLED || BZERO_ENABLED || KUBE_ENABLED) {
 // These suites are based on testing allTargets use SSM_ENABLED or BZERO_ENABLED
 // environment variables to control which targets are created
 if(SSM_ENABLED || BZERO_ENABLED) {
-    connectSuite();
-    sessionRecordingSuite();
-    sshSuite();
+    // connectSuite();
+    // sessionRecordingSuite();
+    // sshSuite();
 
     if (IN_CI && NOT_USING_RUNNER) {
         // Only run group tests if we are in CI and talking to staging or dev
@@ -299,7 +295,7 @@ if(SSM_ENABLED || BZERO_ENABLED) {
 
 // BZero only test suites
 if(BZERO_ENABLED) {
-    dynamicAccessSuite();
+    // dynamicAccessSuite();
 }
 
 // Only run the agent container suite when we are running
@@ -357,7 +353,7 @@ if (API_ENABLED) {
 }
 
 if (AGENT_RECOVERY_ENABLED && BZERO_ENABLED && process.env.TEST_RUNNER_KUBE_CONFIG) {
-    logger.info("Running agent recovery tests");
+    logger.info('Running agent recovery tests');
     agentRecoverySuite(process.env.TEST_RUNNER_KUBE_CONFIG, process.env.TEST_RUNNER_UNIQUE_ID);
 } else {
     logger.info('Skipping agent recovery tests.');

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -94,6 +94,7 @@ const VT_ENABLED = process.env.VT_ENABLED ? (process.env.VT_ENABLED === 'true') 
 const BZERO_ENABLED = process.env.BZERO_ENABLED ? (process.env.BZERO_ENABLED === 'true') : true;
 const SSM_ENABLED =  process.env.SSM_ENABLED ? (process.env.SSM_ENABLED === 'true') : true;
 const API_ENABLED = process.env.API_ENABLED ? (process.env.API_ENABLED === 'true') : true;
+const AGENT_RECOVERY_ENABLED = process.env.AGENT_RECOVERY_ENABLED ? (process.env.AGENT_RECOVERY_ENABLED === 'true') : true;
 export const IN_PIPELINE = process.env.IN_PIPELINE ? process.env.IN_PIPELINE === 'true' : false;;
 
 export const IN_CI = process.env.BZERO_IN_CI ? (process.env.BZERO_IN_CI === '1') : false;
@@ -355,11 +356,11 @@ if (API_ENABLED) {
     }
 }
 
-if (process.env.TEST_RUNNER_KUBE_CONFIG) {
+if (AGENT_RECOVERY_ENABLED && BZERO_ENABLED && process.env.TEST_RUNNER_KUBE_CONFIG) {
     logger.info("Running agent recovery tests");
     agentRecoverySuite(process.env.TEST_RUNNER_KUBE_CONFIG, process.env.TEST_RUNNER_UNIQUE_ID);
 } else {
-    logger.info('Skipping agent recovery tests because we are not running against a test runner.');
+    logger.info('Skipping agent recovery tests.');
 }
 
 // Always run the version suite

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -57,8 +57,6 @@ import { dynamicAccessSuite } from './suites/dynamic-access';
 // of the CD pipeline in the AWS prod account it will be 'stage'
 const configName = envMap.configName;
 
-export const testStartTime = new Date();
-
 // Setup services used for running system tests
 export const loggerConfigService = new LoggerConfigService(configName, envMap.configDir);
 export const logger = new Logger(loggerConfigService, false, false, true);

--- a/src/system-tests/tests/utils/connect-utils.ts
+++ b/src/system-tests/tests/utils/connect-utils.ts
@@ -83,6 +83,8 @@ export class ConnectTestUtils {
     }
 
     private async runShellConnectTestHelper(connectTarget: ConnectTarget, stringToEcho: string, exit: boolean): Promise<string> {
+        const startTime = new Date();
+
         // Spy on result of the ConnectionHttpService.CreateUniversalConnection
         // call. This spy is used to return the connectionId. For non-DAT
         // targets its also used to assert the correct regional connection node
@@ -117,8 +119,8 @@ export class ConnectTestUtils {
         }
 
         // Ensure that the created and connect event exists
-        await this.ensureConnectionEvent(connectTarget, ConnectionEventType.ClientConnect);
-        await this.ensureConnectionEvent(connectTarget, ConnectionEventType.Created);
+        await this.ensureConnectionEvent(connectTarget, ConnectionEventType.ClientConnect, startTime);
+        await this.ensureConnectionEvent(connectTarget, ConnectionEventType.Created, startTime);
 
         await this.testEchoCommand(connectTarget, stringToEcho);
 
@@ -142,7 +144,7 @@ export class ConnectTestUtils {
             await connectPromise;
 
             // Ensure that the client disconnect event is here
-            await this.ensureConnectionEvent(connectTarget, ConnectionEventType.ClientDisconnect);
+            await this.ensureConnectionEvent(connectTarget, ConnectionEventType.ClientDisconnect, startTime);
         }
 
         return gotUniversalConnectionResponse.connectionId;
@@ -205,7 +207,7 @@ export class ConnectTestUtils {
      * @param connectTarget The target expected to connect
      * @param eventType The event type to look for
      */
-    public async ensureConnectionEvent(connectTarget: ConnectTarget, eventType: ConnectionEventType) {
+    public async ensureConnectionEvent(connectTarget: ConnectTarget, eventType: ConnectionEventType, startTime: Date) {
         await this.testUtils.EnsureConnectionEventCreated({
             targetId: connectTarget.id,
             targetName: connectTarget.name,
@@ -215,7 +217,7 @@ export class ConnectTestUtils {
             connectionEventType: eventType,
             // All shell connections created by the zli exist in the cli-space
             sessionName: 'cli-space'
-        });
+        }, startTime);
     }
 
     /**

--- a/src/system-tests/tests/utils/kube-utils.ts
+++ b/src/system-tests/tests/utils/kube-utils.ts
@@ -1,5 +1,5 @@
 import * as k8s from '@kubernetes/client-node';
-import { Logger } from '../services/logger/logger.service';
+import { Logger } from '../../../services/logger/logger.service';
 
 export async function execOnPod(k8sExec: k8s.Exec, pod: k8s.V1Pod, containerName: string, command: string | string[], logger: Logger) {
     if(! pod || !pod.metadata || !pod.metadata.name || !pod.metadata.namespace) {

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -3,7 +3,7 @@ import *  as fs from 'fs';
 import { ConfigService } from '../../../../src/services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
 import { EventsHttpService } from '../../../../src/http-services/events/events.http-server';
-import { configService, testStartTime } from '../system-test';
+import { configService } from '../system-test';
 import { LoggerConfigService } from '../../../../src/services/logger/logger-config.service';
 import { SubjectType } from '../../../../webshell-common-ts/http/v2/common.types/subject.types';
 import { CommandEventDataMessage } from '../../../../webshell-common-ts/http/v2/event/types/command-event-data-message';
@@ -113,7 +113,7 @@ export class TestUtils {
      * @param retryInterval Time to wait in-between polls of the
      * GetConnectionsEvents() API
      */
-    public async EnsureConnectionEventCreated(partialEvent: Partial<ConnectionEventDataMessage>, timeout: number = 25 * 1000, retryInterval: number = SLEEP_TIME * 1000) : Promise<void>
+    public async EnsureConnectionEventCreated(partialEvent: Partial<ConnectionEventDataMessage>, startTime: Date, timeout: number = 25 * 1000, retryInterval: number = SLEEP_TIME * 1000) : Promise<void>
     {
         const defaultExpectedEnvironmentName =
         // If environmentId is specified and is not equal to the Guid.empty ID (used by SSM targets)
@@ -150,7 +150,7 @@ export class TestUtils {
         return await this.waitForExpect(
             async () => {
                 const gotEvents = await this.eventsService.GetConnectionEvents(
-                    testStartTime,
+                    startTime,
                     [configService.me().id],
                     partialEvent.targetId ? [partialEvent.targetId] : []
                 );

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -63,6 +63,19 @@ export class TestUtils {
         return toReturn;
     }
 
+    /**
+     * Polls for agent status changes events until it finds a specific event or
+     * times out and throws an error
+     * @param targetId The target to search for  
+     * @param partialEvent A partial expected event to search for. Any
+     * properties that are omitted from the partial event will default to
+     * expect.anything() instead 
+     * @param startTime Optional start time to filter events
+     * @param endTime Optional end time to filter events
+     * @param timeout Max time to wait for the event before timing out
+     * @param retryInterval Time to wait in between polls to get new events
+     */
+
     public async EnsureAgentStatusEvent(targetId: string, partialEvent: Partial<AgentStatusChangeData>, startTime?: Date, endTime?: Date, timeout: number = 25 * 100, retryInterval: number = 5 * 1000) {
         const defaults: AgentStatusChangeData = {
             statusChange: expect.anything(),
@@ -79,7 +92,6 @@ export class TestUtils {
                 // Use arrayContaining, so that got value can contain extra
                 // elements. Include explicit generic constraint, so that jest
                 // prints the object if something does not match.
-                console.log(JSON.stringify(gotEvents, null, 2));
                 expect(gotEvents).toEqual<ConnectionEventDataMessage[]>(expect.arrayContaining([expectedEvent]));
             },
             timeout,

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -73,8 +73,6 @@ export class TestUtils {
         };
 
         const expectedEvent : AgentStatusChangeData = { ...defaults, ...partialEvent};
-
-        // TODO: Add startTime filter
         return await this.waitForExpect(
             async () => {
                 const gotEvents = await this.eventsService.GetAgentStatusChangeEvents(targetId, startTime, endTime);

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -66,10 +66,10 @@ export class TestUtils {
     /**
      * Polls for agent status changes events until it finds a specific event or
      * times out and throws an error
-     * @param targetId The target to search for  
+     * @param targetId The target to search for
      * @param partialEvent A partial expected event to search for. Any
      * properties that are omitted from the partial event will default to
-     * expect.anything() instead 
+     * expect.anything() instead
      * @param startTime Optional start time to filter events
      * @param endTime Optional end time to filter events
      * @param timeout Max time to wait for the event before timing out

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -92,7 +92,7 @@ export class TestUtils {
                 // Use arrayContaining, so that got value can contain extra
                 // elements. Include explicit generic constraint, so that jest
                 // prints the object if something does not match.
-                expect(gotEvents).toEqual<ConnectionEventDataMessage[]>(expect.arrayContaining([expectedEvent]));
+                expect(gotEvents).toEqual<AgentStatusChangeData[]>(expect.arrayContaining([expectedEvent]));
             },
             timeout,
             retryInterval

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -10,7 +10,6 @@ import { CommandEventDataMessage } from '../../../../webshell-common-ts/http/v2/
 import { ConnectionEventDataMessage } from '../../../../webshell-common-ts/http/v2/event/types/connection-event-data-message';
 import { EnvironmentHttpService } from '../../../../src/http-services/environment/environment.http-services';
 import { AgentStatusChangeData } from '../../../../webshell-common-ts/http/v2/event/types/agent-status-change-data.types';
-import { TargetType } from '../../../../webshell-common-ts/http/v2/target/types/target.types';
 
 const pids = require('port-pid');
 
@@ -80,6 +79,7 @@ export class TestUtils {
                 // Use arrayContaining, so that got value can contain extra
                 // elements. Include explicit generic constraint, so that jest
                 // prints the object if something does not match.
+                console.log(JSON.stringify(gotEvents, null, 2));
                 expect(gotEvents).toEqual<ConnectionEventDataMessage[]>(expect.arrayContaining([expectedEvent]));
             },
             timeout,

--- a/src/system-tests/tests/utils/test-utils.ts
+++ b/src/system-tests/tests/utils/test-utils.ts
@@ -64,12 +64,11 @@ export class TestUtils {
         return toReturn;
     }
 
-    public async EnsureAgentStatusEvent(targetId: string, partialEvent: Partial<AgentStatusChangeData>, timeout: number = 25 * 100, retryInterval: number = 5 * 1000) {
+    public async EnsureAgentStatusEvent(targetId: string, partialEvent: Partial<AgentStatusChangeData>, startTime?: Date, endTime?: Date, timeout: number = 25 * 100, retryInterval: number = 5 * 1000) {
         const defaults: AgentStatusChangeData = {
-            id: expect.anything(),
             statusChange: expect.anything(),
             timeStamp: expect.anything(),
-            origin: expect.anything(),
+            reason: expect.anything(),
             agentPublicKey: expect.anything(),
         };
 
@@ -78,7 +77,7 @@ export class TestUtils {
         // TODO: Add startTime filter
         return await this.waitForExpect(
             async () => {
-                const gotEvents = await this.eventsService.GetAgentStatusChangeEvents(targetId, TargetType.Bzero);
+                const gotEvents = await this.eventsService.GetAgentStatusChangeEvents(targetId, startTime, endTime);
 
                 // Use arrayContaining, so that got value can contain extra
                 // elements. Include explicit generic constraint, so that jest

--- a/src/utils/kube-utils.ts
+++ b/src/utils/kube-utils.ts
@@ -1,0 +1,28 @@
+import * as k8s from '@kubernetes/client-node';
+import { Logger } from '../services/logger/logger.service';
+
+export async function execOnPod(k8sExec: k8s.Exec, pod: k8s.V1Pod, containerName: string, command: string | string[], logger: Logger) {
+    if(! pod || !pod.metadata || !pod.metadata.name || !pod.metadata.namespace) {
+        throw Error(`Cannot exec on pod without name/namespace metadata: ${JSON.stringify(pod, null, 2)}`);
+    }
+
+    await k8sExec.exec(
+        pod.metadata.namespace, pod.metadata.name, containerName, command, process.stdout, process.stderr, null, false,
+        (status: k8s.V1Status) => {
+            logger.info(`Kube exec command "${command}": exited with status: ${JSON.stringify(status, null, 2)}`);
+        }
+    );
+}
+
+export async function deletePod(k8sApi: k8s.CoreV1Api, pod: k8s.V1Pod) {
+    if(! pod || !pod.metadata || !pod.metadata.name || !pod.metadata.namespace) {
+        throw Error(`Cannot delete pod without name/namespace metadata: ${JSON.stringify(pod, null, 2)}`);
+    }
+
+    k8sApi.deleteNamespacedPod(pod.metadata.name, pod.metadata.namespace);
+}
+
+export async function getPodWithLabelSelector(k8sApi: k8s.CoreV1Api, namespace: string, labelSelector: {[key: string]: string}) {
+    const labelSelectorString = Object.keys(labelSelector).map(k => `${k}=${labelSelector[k]}`).join(',');
+    return k8sApi.listNamespacedPod(namespace, undefined, undefined, undefined, undefined, labelSelectorString);
+}


### PR DESCRIPTION
## Description of the change

+ Adds new system test environment variables that expose the test runner cluster config so we can construct k8s client to interact with the cluster as part of the tests. Dependent on https://github.com/bastionzero/cwc-infra/pull/526

+ Add test that restarts the bastion and verifies that the agent control channel comes back online and we can connect to the target

## Testing

Describe how to test this PR....

**backend branch:**
**bzero branch:** 

#### Ready to run system tests?

- [x] Yes

## Relevant release note information

Release Notes: Adds new agent recovery system test suite to test agent recovery functions when various backend services fail 

## Related JIRA tickets

Relates to JIRA: CWC-2053

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: