### PR TITLE
Adjust user/register to not call user/me before mfaed [CWC-2174]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.11.11",
+  "version": "6.11.12",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -704,6 +704,12 @@ export class CliDriver
                 async () => {
                     const userHttpService = new UserHttpService(this.configService, this.logger);
                     await userHttpService.Register();
+                    // Update me section of the config in case this is a new login or any
+                    // user information has changed since last login
+                    const me = await userHttpService.Me();
+                    this.configService.setMe(me);
+
+
                 }
             )
             .command(

--- a/src/handlers/login/login.handler.ts
+++ b/src/handlers/login/login.handler.ts
@@ -106,6 +106,11 @@ export async function login(keySplittingService: KeySplittingService, configServ
         break;
     }
 
+    // Update me section of the config in case this is a new login or any
+    // user information has changed since last login
+    const me = await userHttpService.Me();
+    configService.setMe(me);
+
     // clear temporary SSH files
     removeIfExists(configService.sshKeyPath());
     removeIfExists(configService.sshKnownHostsPath());

--- a/src/http-services/user/user.http-services.ts
+++ b/src/http-services/user/user.http-services.ts
@@ -39,11 +39,6 @@ export class UserHttpService extends HttpService
             this.configService.setSessionToken(cookiesDict['sessionToken'].value);
         }
 
-        // Update me section of the config in case this is a new login or any
-        // user information has changed since last login
-        const me = await this.Me();
-        this.configService.setMe(me);
-
         return resp;
     }
 

--- a/src/services/oauth/oauth.service.ts
+++ b/src/services/oauth/oauth.service.ts
@@ -347,6 +347,10 @@ export class OAuthService implements IDisposable {
 
                 const userHttpService = new UserHttpService(this.configService, this.logger);
                 await userHttpService.Register();
+                // Update me section of the config in case this is a new login or any
+                // user information has changed since last login
+                const me = await userHttpService.Me();
+                this.configService.setMe(me);
             }
         } else {
             throw new UserNotLoggedInError();

--- a/src/system-tests/tests/system-test.ts
+++ b/src/system-tests/tests/system-test.ts
@@ -207,6 +207,10 @@ beforeAll(async () => {
     // Ask bastion for new session token
     const userHttpService = new UserHttpService(configService, logger);
     await userHttpService.Register();
+    // Update me section of the config in case this is a new login or any
+    // user information has changed since last login
+    const me = await userHttpService.Me();
+    configService.setMe(me);
 
     // Create a new api key that can be used for system tests
     [systemTestRESTApiKey, systemTestRegistrationApiKey] = await setupSystemTestApiKeys();


### PR DESCRIPTION
## Description of the change

Removed call to user/me from inside register call so when mfa is enabled we firstly mfa and then call user/me.

## Testing

Describe how to test this PR....

**backend branch:** 
**bzero branch:** 

#### Ready to run system tests?

- [X] Yes

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-2174

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: