### PR TITLE
CLI Exit Refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.20.2",
+  "version": "6.20.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bastionzero/zli",
-      "version": "6.20.2",
+      "version": "6.20.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/iam-credentials": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastionzero/zli",
-  "version": "6.20.2",
+  "version": "6.20.3",
   "description": "BastionZero cli",
   "repository": {
     "type": "git",

--- a/src/cli-driver.ts
+++ b/src/cli-driver.ts
@@ -1013,10 +1013,11 @@ Need help? https://cloud.bastionzero.com/support`)
         try {
             const { baseCmd, parsedArgv } = makeCaseInsensitive(this.availableCommands, argv);
             await this.getCliDriver(isSystemTest, baseCmd).parseAsync(parsedArgv, {}, callback);
+            cleanExit(0, this.logger);
         } catch (err) {
             if (this.logger) {
                 if (err) {
-                    if (typeof err === 'string') {
+                    if (typeof err === 'string' && err.length > 0) {
                         this.logger.error(err);
                     } else {
                         this.logger.error(err.message);
@@ -1027,7 +1028,7 @@ Need help? https://cloud.bastionzero.com/support`)
                 await cleanExit(1, this.logger);
             } else {
                 if (err) {
-                    if (typeof err === 'string') {
+                    if (typeof err === 'string' && err.length > 0) {
                         console.error(err);
                     } else {
                         console.error(err.message);

--- a/src/handlers/api-key/create-api-key.handler.ts
+++ b/src/handlers/api-key/create-api-key.handler.ts
@@ -3,7 +3,6 @@ import { ConfigService } from '../../services/config/config.service';
 import yargs from 'yargs';
 import { createApiKeyArgs } from './create-api-key.command-builder';
 import { ApiKeyHttpService } from '../../http-services/api-key/api-key.http-services';
-import { cleanExit } from '../clean-exit.handler';
 
 export async function createApiKeyHandler(
     argv: yargs.Arguments<createApiKeyArgs>,
@@ -21,6 +20,4 @@ export async function createApiKeyHandler(
         logger.info(`Secret: ${createResp.secret}`);
         logger.info('\nPlease write your secret down. It cannot be recovered later.');
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/authorized-github-action/create-authorized-github-action.handler.ts
+++ b/src/handlers/authorized-github-action/create-authorized-github-action.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../services/logger/logger.service';
 import { ConfigService } from '../../services/config/config.service';
-import { cleanExit } from '../clean-exit.handler';
 import yargs from 'yargs';
 import { createAuthorizedGithubActionArgs } from './create-authorized-github-action.command-builder';
 import { AuthorizedGithubActionHttpService } from '../../http-services/authorized-github-action/authorized-github-action.http-services';
@@ -10,8 +9,7 @@ import { SubjectType } from '../../../webshell-common-ts/http/v2/common.types/su
 export async function createAuthorizedGithubActionHandler(configService: ConfigService, logger: Logger, argv : yargs.Arguments<createAuthorizedGithubActionArgs>) {
 
     if(configService.me().type != SubjectType.User) {
-        logger.error(`You cannot authorize Github Actions when logged in as ${configService.me().type}`);
-        await cleanExit(1, logger);
+        throw new Error(`You cannot authorize Github Actions when logged in as ${configService.me().type}`);
     }
 
     const authorizedGithubActionHttpService = new AuthorizedGithubActionHttpService(configService, logger);
@@ -21,6 +19,4 @@ export async function createAuthorizedGithubActionHandler(configService: ConfigS
     };
     const resp = await authorizedGithubActionHttpService.CreateAuthorizedGithubAction(req);
     logger.info(`Successfully authorized Github Action ${resp.githubActionId}`);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/authorized-github-action/delete-authorized-github-action.handler.ts
+++ b/src/handlers/authorized-github-action/delete-authorized-github-action.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../services/logger/logger.service';
 import { ConfigService } from '../../services/config/config.service';
-import { cleanExit } from '../clean-exit.handler';
 import yargs from 'yargs';
 import { AuthorizedGithubActionHttpService } from '../../http-services/authorized-github-action/authorized-github-action.http-services';
 import { deleteAuthorizedGithubActionArgs } from './delete-authorized-github-action.command-builder';
@@ -13,12 +12,9 @@ export async function deleteAuthorizedGithubActionHandler(configService: ConfigS
     // If this action does not exist
     const authorizedGithubAction = authorizedGithubActions.find(a => a.githubActionId === argv.githubActionId);
     if (!authorizedGithubAction) {
-        logger.error(`No authorized Github Action with ID ${argv.githubActionId} exists`);
-        await cleanExit(1, logger);
+        throw new Error(`No authorized Github Action with ID ${argv.githubActionId} exists`);
     }
 
     await authorizedGithubActionHttpService.DeleteAuthorizedGithubAction(authorizedGithubAction.id);
     logger.info(`Successfully deleted Github Action ${authorizedGithubAction.githubActionId}`);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/authorized-github-action/list-authorized-github-action.handler.ts
+++ b/src/handlers/authorized-github-action/list-authorized-github-action.handler.ts
@@ -2,7 +2,6 @@ import { AuthorizedGithubActionHttpService } from '../../../src/http-services/au
 import { UserHttpService } from '../../../src/http-services/user/user.http-services';
 import { getTableOfAuthorizedGithubActions } from '../../../src/utils/utils';
 import yargs from 'yargs';
-import { cleanExit } from '../clean-exit.handler';
 import { listAuthorizedGithubActionsArgs } from './list-authorized-github-actions.command-builder';
 import { ConfigService } from '../../../src/services/config/config.service';
 import { Logger } from '../../../src/services/logger/logger.service';
@@ -21,7 +20,7 @@ export async function listAuthorizedGithubActionsHandler(
     } else {
         if (authorizedGithubActions.length === 0){
             logger.info('There are no authorized Github Actions');
-            await cleanExit(0, logger);
+            return;
         }
         const userHttpService = new UserHttpService(configService, logger);
         const users = await userHttpService.ListUsers();
@@ -34,6 +33,4 @@ export async function listAuthorizedGithubActionsHandler(
         const tableString = getTableOfAuthorizedGithubActions(authorizedGithubActions, userMap);
         console.log(tableString);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/close-connection/close-connection.handler.ts
+++ b/src/handlers/close-connection/close-connection.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../services/config/config.service';
 import { Logger } from '../../services/logger/logger.service';
-import { cleanExit } from '../clean-exit.handler';
 import { ConnectionHttpService } from '../../http-services/connection/connection.http-services';
 import { closeConnectionArgs } from './close-connection.command-builder';
 import yargs from 'yargs';
@@ -62,6 +61,4 @@ export async function closeConnectionHandler(
         await connectionHttpService.CloseConnection(argv.connectionId);
         logger.info(`Connection ${argv.connectionId} successfully closed`);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/configure/config-default-targetuser.handler.ts
+++ b/src/handlers/configure/config-default-targetuser.handler.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
 import { ConfigService } from '../../services/config/config.service';
 import { Logger } from '../../services/logger/logger.service';
-import { cleanExit } from '../clean-exit.handler';
 import { configDefaultTargetUserArgs } from './config-default-targetuser.command-builder';
 import { ConnectConfig } from '../../services/config/config.service.types';
 
@@ -9,8 +8,7 @@ export async function configDefaultTargetUserHandler(argv: yargs.Arguments<confi
     // This is handled manually so that the user isn't required
     // to have a positional argument to use the --reset flag
     if(argv.targetUser === undefined && argv.reset === undefined) {
-        logger.error('A target user must be provided for this command.');
-        await cleanExit(0, logger);
+        throw new Error('A target user must be provided for this command.');
     }
 
     let connectConfig: ConnectConfig;
@@ -24,5 +22,4 @@ export async function configDefaultTargetUserHandler(argv: yargs.Arguments<confi
     }
     configService.setConnectConfig(connectConfig);
     logger.info(loggerStatement);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/configure/config.handler.ts
+++ b/src/handlers/configure/config.handler.ts
@@ -1,11 +1,9 @@
 import { ConfigService } from '../../services/config/config.service';
 import { Logger } from '../../services/logger/logger.service';
 import { LoggerConfigService } from '../../services/logger/logger-config.service';
-import { cleanExit } from '../clean-exit.handler';
 
 export async function configHandler(logger: Logger, configService: ConfigService, loggerConfigService: LoggerConfigService) {
     logger.info(`You can edit your config here: ${configService.getConfigPath()}`);
     logger.info(`You can find your zli log files here: ${loggerConfigService.logPath()}`);
     logger.info(`You can find your daemon log files here: ${loggerConfigService.daemonLogPath()}`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/connect/connect.handler.ts
+++ b/src/handlers/connect/connect.handler.ts
@@ -59,12 +59,10 @@ export async function connectHandler(
             const exitCode = await shellConnectHandler(createUniversalConnectionResponse.targetType, createUniversalConnectionResponse.targetUser, createUniversalConnectionResponse, configService, logger, loggerConfigService);
 
             if (exitCode !== 0) {
-                const errMsg = handleExitCode(exitCode, createUniversalConnectionResponse);
-                if (errMsg.length > 0) {
-                    logger.error(errMsg);
-                }
+                const err = handleExitCode(exitCode, createUniversalConnectionResponse);
+                throw err;
             }
-            return exitCode;
+            return;
         case TargetType.Db:
             return await dbConnectHandler(argv, createUniversalConnectionResponse.splitCert, createUniversalConnectionResponse.targetId, createUniversalConnectionResponse.targetUser, createUniversalConnectionResponse, configService, logger, loggerConfigService);
         case TargetType.Web:
@@ -72,8 +70,7 @@ export async function connectHandler(
         case TargetType.Cluster:
             return await startKubeDaemonHandler(argv, createUniversalConnectionResponse.targetId, createUniversalConnectionResponse.targetUser, createUniversalConnectionResponse, configService, logger, loggerConfigService);
         default:
-            logger.error(`Unhandled target type ${createUniversalConnectionResponse.targetType}`);
-            return -1;
+            throw new Error(`Unhandled target type ${createUniversalConnectionResponse.targetType}`);
         }
     }
     catch(err)

--- a/src/handlers/default-target-group/default-target-group.handler.ts
+++ b/src/handlers/default-target-group/default-target-group.handler.ts
@@ -2,7 +2,6 @@ import { Logger } from '../../services/logger/logger.service';
 import { ConfigService } from '../../services/config/config.service';
 import yargs from 'yargs';
 import { defaultTargetGroupArgs } from './default-target-group.command-builder';
-import { cleanExit } from '../clean-exit.handler';
 
 export async function defaultTargetGroupHandler(configService: ConfigService, logger: Logger, argv: yargs.Arguments<defaultTargetGroupArgs>) {
     // Open up our global kube config
@@ -24,6 +23,4 @@ export async function defaultTargetGroupHandler(configService: ConfigService, lo
         const currentDefaultGroups = kubeGlobalConfig.defaultTargetGroups;
         logger.info(`Current default group is set to: ${currentDefaultGroups}`);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/disconnect/disconnect.handler.ts
+++ b/src/handlers/disconnect/disconnect.handler.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
 import { ConfigService } from '../../services/config/config.service';
 import { Logger } from '../../services/logger/logger.service';
-import { cleanExit } from '../clean-exit.handler';
 import { disconnectArgs } from './disconnect.command-builder';
 import { newDbDaemonManagementService, newKubeDaemonManagementService } from '../../services/daemon-management/daemon-management.service';
 import { DisconnectResult } from '../../services/daemon-management/types/disconnect-result.types';
@@ -45,7 +44,6 @@ export async function disconnectHandler(
         const dbDaemonManagementService = newDbDaemonManagementService(configService);
         await handleDisconnect(dbDaemonManagementService, logger);
     }
-    await cleanExit(0, logger);
 }
 
 export interface IDaemonDisconnector<T extends DaemonConfig> {

--- a/src/handlers/generate/bash/generate-bash.handler.ts
+++ b/src/handlers/generate/bash/generate-bash.handler.ts
@@ -8,7 +8,6 @@ import { generateBashArgs } from './generate-bash.command-builder';
 import { getEnvironmentFromName } from '../../../utils/utils';
 import { ScriptTargetNameOption } from '../../../../webshell-common-ts/http/v2/autodiscovery-script/types/script-target-name-option.types';
 import { EnvironmentHttpService } from '../../../http-services/environment/environment.http-services';
-import { cleanExit } from '../../clean-exit.handler';
 
 export async function generateBashHandler(
     argv: yargs.Arguments<generateBashArgs>,
@@ -53,6 +52,4 @@ export async function generateBashHandler(
     } else {
         console.log(script);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/generate/kube/generate-kube-config.handler.ts
+++ b/src/handlers/generate/kube/generate-kube-config.handler.ts
@@ -9,7 +9,6 @@ import { getAllRunningDaemons, IDaemonStatusRetriever, newKubeDaemonManagementSe
 import { KubeConfig as ZliKubeConfig, KubeDaemonSecurityConfig } from '../../../services/config/config.service.types';
 import { ILogger } from '../../../../webshell-common-ts/logging/logging.types';
 import { handleDisconnect, IDaemonDisconnector } from '../../disconnect/disconnect.handler';
-import { cleanExit } from '../../clean-exit.handler';
 
 export async function generateKubeConfigHandler(
     argv: yargs.Arguments<generateKubeConfigArgs>,
@@ -31,8 +30,6 @@ export async function generateKubeConfigHandler(
 
     if (generatedKubeConfigAsYaml)
         console.log(generatedKubeConfigAsYaml);
-
-    await cleanExit(0, logger);
 }
 
 export interface IGenerateKubeConfigManagementService extends IDaemonDisconnector<ZliKubeConfig>, IDaemonStatusRetriever<ZliKubeConfig> {

--- a/src/handlers/generate/kube/generate-kube-yaml.handler.ts
+++ b/src/handlers/generate/kube/generate-kube-yaml.handler.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import util from 'util';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { generateKubeYamlArgs } from './generate-kube.command-builder';
 import { getEnvironmentFromName } from '../../../utils/utils';
 import { KubeHttpService } from '../../../http-services/targets/kube/kube.http-services';
@@ -16,8 +15,7 @@ export async function generateKubeYamlHandler(
 ) {
     // First check all the required args
     if (argv.clusterName == null) {
-        logger.error('Please make sure you have passed the clusterName positional argument before trying to generate a yaml!');
-        await cleanExit(1, logger);
+        throw new Error('Please make sure you have passed the clusterName positional argument before trying to generate a yaml!');
     }
 
     const outputFileArg = argv.outputFile;
@@ -54,5 +52,4 @@ export async function generateKubeYamlHandler(
     } else {
         console.log(kubeYaml.yaml);
     }
-    await cleanExit(0, logger);
 }

--- a/src/handlers/generate/ssh/generate-ssh-config.handler.ts
+++ b/src/handlers/generate/ssh/generate-ssh-config.handler.ts
@@ -7,7 +7,6 @@ import { PolicyQueryHttpService } from '../../../http-services/policy-query/poli
 import { SshTargetsResponse } from '../../../../webshell-common-ts/http/v2/policy-query/responses/tunnels.response';
 import { buildSshConfigStrings } from './generate-ssh-proxy.handler';
 import { generateSshConfigArgs } from './generate-ssh-config.command-builder';
-import { cleanExit } from '../../clean-exit.handler';
 
 // bound refers to star boundaries set for the comments
 const bound = '*'.repeat(80);
@@ -58,8 +57,6 @@ export async function generateSshConfigHandler(argv: yargs.Arguments<generateSsh
         deleteBzConfigContents(userConfigPath, bzConfigPath, logger);
         logger.info('You do not have tunnel or file transfer access to any targets. BZ SSH configuration file not generated.');
     }
-
-    await cleanExit(0, logger);
 }
 
 /**

--- a/src/handlers/generate/ssh/generate-ssh-proxy.handler.ts
+++ b/src/handlers/generate/ssh/generate-ssh-proxy.handler.ts
@@ -1,5 +1,4 @@
 import { exec } from 'child_process';
-import { cleanExit } from '../../clean-exit.handler';
 import { promisify } from 'util';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
@@ -20,8 +19,6 @@ Then you can use native ssh to connect to any of your ssm targets using the foll
 
 ssh <user>@${prefix}<ssm-target-id-or-name>
 `);
-
-    await cleanExit(0, logger);
 }
 
 export async function buildSshConfigStrings(configService: ConfigService, processName: string, logger: Logger, addProxyPrefix: boolean = false) {

--- a/src/handlers/list-connections/list-connections.handler.ts
+++ b/src/handlers/list-connections/list-connections.handler.ts
@@ -5,7 +5,6 @@ import { listConnectionsArgs } from './list-connections.command-builder';
 import yargs from 'yargs';
 import { ConnectionInfo } from '../../services/list-connections/list-connections.service.types';
 import { listOpenDbConnections, listOpenKubeConnections, listOpenShellConnections } from '../../services/list-connections/list-connections.service';
-import { cleanExit } from '../clean-exit.handler';
 
 export async function listConnectionsHandler(
     argv: yargs.Arguments<listConnectionsArgs>,
@@ -61,8 +60,6 @@ export async function listConnectionsHandler(
         ]);
         await printTableOrJson('all', normalizeConnectionInfos([...shellConnections, ...dbConnections, ...kubeConnections]));
     }
-
-    await cleanExit(0, logger);
 }
 
 // This type should conform to the table output's columns, so that the --json

--- a/src/handlers/list-daemons/list-daemons.handler.ts
+++ b/src/handlers/list-daemons/list-daemons.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../services/logger/logger.service';
 import { ConfigService } from '../../services/config/config.service';
-import { cleanExit } from '../clean-exit.handler';
 import { createTableWithWordWrap, getTableOfWebStatus, toUpperCase } from '../../utils/utils';
 import { listDaemonsArgs } from './list-daemons.command-builder';
 import yargs from 'yargs';
@@ -28,8 +27,6 @@ export async function listDaemonsHandler(
     if (targetType == 'all' || targetType == 'db') {
         await dbStatusHandler(configService, logger);
     }
-
-    await cleanExit(0, logger);
 }
 
 async function webStatusHandler(

--- a/src/handlers/list-targets/list-targets.handler.ts
+++ b/src/handlers/list-targets/list-targets.handler.ts
@@ -5,7 +5,6 @@ import {
     parseTargetStatus
 } from '../../utils/utils';
 import { Logger } from '../../services/logger/logger.service';
-import { cleanExit } from '../clean-exit.handler';
 import { includes, map, uniq } from 'lodash';
 import { ConfigService } from '../../services/config/config.service';
 import yargs from 'yargs';
@@ -76,6 +75,4 @@ export async function listTargetsHandler(
             console.log(tableString);
         }
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/logout/logout.handler.ts
+++ b/src/handlers/logout/logout.handler.ts
@@ -1,4 +1,3 @@
-import { cleanExit } from '../clean-exit.handler';
 import fs from 'fs';
 import { DbConfig, KubeConfig, WebConfig } from '../../services/config/config.service.types';
 import { Logger } from '../../services/logger/logger.service';
@@ -26,7 +25,6 @@ export async function logoutHandler(
         fileRemover,
         logger
     );
-    await cleanExit(0, logger);
 }
 
 export interface ILogoutConfigService {

--- a/src/handlers/policy/policy-create/create-cluster-policy.handler.ts
+++ b/src/handlers/policy/policy-create/create-cluster-policy.handler.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { createClusterPolicyArgs } from './create-policy.command-builder';
 import { getGroupsByName, getEnvironmentByName, getSubjectsByEmail, checkAllIdentifiersExist, checkAllIdentifiersAreSingle, getTargetsByNameOrId } from '../../../utils/policy-utils';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
@@ -27,8 +26,7 @@ export async function createClusterPolicyHandler(argv: yargs.Arguments<createClu
     // If a value is provided for neither then throw an error
     // Yargs will handle when a value is passed in for both
     if(argv.clusters === undefined && argv.environments === undefined) {
-        logger.error('Must exclusively provide a value for clusters or environments');
-        await cleanExit(1, logger);
+        throw new Error('Must exclusively provide a value for clusters or environments');
     }
 
     let subjectsEmails: string[];
@@ -97,6 +95,4 @@ export async function createClusterPolicyHandler(argv: yargs.Arguments<createClu
     });
 
     logger.warn(`Successfully created a new Cluster Policy. Name: ${kubeClusterPolicy.name} ID: ${kubeClusterPolicy.id}`);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-create/create-proxy-policy.handler.ts
+++ b/src/handlers/policy/policy-create/create-proxy-policy.handler.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { createProxyPolicyArgs } from './create-policy.command-builder';
 import { getGroupsByName, getEnvironmentByName, getSubjectsByEmail, getTargetsByNameOrId, checkAllIdentifiersExist, checkAllIdentifiersAreSingle } from '../../../utils/policy-utils';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
@@ -25,8 +24,7 @@ export async function createProxyPolicyHandler(argv: yargs.Arguments<createProxy
     // If a value is provided for neither then throw an error
     // Yargs will handle when a value is passed in for both
     if(argv.targets === undefined && argv.environments === undefined) {
-        logger.error('Must exclusively provide a value for targets or environments');
-        await cleanExit(1, logger);
+        throw new Error('Must exclusively provide a value for targets or environments');
     }
 
     let subjectsEmails: string[];
@@ -78,6 +76,4 @@ export async function createProxyPolicyHandler(argv: yargs.Arguments<createProxy
     });
 
     logger.warn(`Successfully created a new Proxy Policy. Name: ${proxyPolicy.name} ID: ${proxyPolicy.id}`);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-create/create-recording-policy.handler.ts
+++ b/src/handlers/policy/policy-create/create-recording-policy.handler.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { createRecordingPolicyArgs } from './create-policy.command-builder';
 import { getGroupsByName, getSubjectsByEmail } from '../../../utils/policy-utils';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
@@ -37,6 +36,4 @@ export async function createRecordingPolicyHandler(argv: yargs.Arguments<createR
     });
 
     logger.warn(`Successfully created a new Session Recording Policy. Name: ${sessionRecordingPolicy.name} ID: ${sessionRecordingPolicy.id}`);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-create/create-tconnect-policy.handler.ts
+++ b/src/handlers/policy/policy-create/create-tconnect-policy.handler.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { createTConnectPolicyArgs } from './create-policy.command-builder';
 import { parseVerbType } from '../../../utils/utils';
 import { getGroupsByName, getEnvironmentByName, getSubjectsByEmail, getTargetsByNameOrId, checkAllIdentifiersExist, checkAllIdentifiersAreSingle } from '../../../utils/policy-utils';
@@ -26,8 +25,7 @@ export async function createTConnectPolicyHandler(argv: yargs.Arguments<createTC
     // If a value is provided for neither then throw an error
     // Yargs will handle when a value is passed in for both
     if(argv.targets === undefined && argv.environments === undefined) {
-        logger.error('Must exclusively provide a value for targets or environments');
-        await cleanExit(1, logger);
+        throw new Error('Must exclusively provide a value for targets or environments');
     }
 
     let subjectsEmails: string[];
@@ -91,6 +89,4 @@ export async function createTConnectPolicyHandler(argv: yargs.Arguments<createTC
     });
 
     logger.warn(`Successfully created a new Target Connect Policy. Name: ${targetConnectPolicy.name} ID: ${targetConnectPolicy.id}`);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-describe-cluster/describe-cluster-policy.handler.ts
+++ b/src/handlers/policy/policy-describe-cluster/describe-cluster-policy.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../../services/logger/logger.service';
 import { ConfigService } from '../../../services/config/config.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { getTableOfDescribeCluster } from '../../../utils/utils';
 import { KubeClusterSummary } from '../../../../webshell-common-ts/http/v2/target/kube/types/kube-cluster-summary.types';
 import { PolicyQueryHttpService } from '../../../http-services/policy-query/policy-query.http-services';
@@ -29,8 +28,7 @@ export async function describeClusterPolicyHandler(
     }
 
     if (clusterSummary == null) {
-        logger.error(`Unable to find cluster with name: ${clusterName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find cluster with name: ${clusterName}`);
     }
 
     // Now make a query to see all policies associated with this cluster
@@ -40,7 +38,7 @@ export async function describeClusterPolicyHandler(
 
     if (kubePolicies.length === 0){
         logger.info('There are no available policies for this cluster.');
-        await cleanExit(0, logger);
+        return;
     }
 
     const policyHttpService = new PolicyHttpService(configService, logger);
@@ -50,6 +48,4 @@ export async function describeClusterPolicyHandler(
     // regular table output
     const tableString = getTableOfDescribeCluster(filteredKubePolicies);
     console.log(tableString);
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-group/add-group-policy.handler.ts
+++ b/src/handlers/policy/policy-group/add-group-policy.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { OrganizationHttpService } from '../../../http-services/organization/organization.http-services';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 import { GroupSummary } from '../../../../webshell-common-ts/http/v2/organization/types/group-summary.types';
@@ -17,8 +16,7 @@ export async function addGroupToPolicyHandler(groupName: string, policyName: str
             groupSummary = group;
     }
     if (groupSummary == undefined) {
-        logger.error(`Unable to find group with name: ${groupName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find group with name: ${groupName}`);
     }
 
     const policyHttpService = new PolicyHttpService(configService, logger);
@@ -26,15 +24,13 @@ export async function addGroupToPolicyHandler(groupName: string, policyName: str
 
     if (policy === null) {
         // Log an error
-        logger.error(`Unable to find policy with name: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find policy with name: ${policyName}`);
     }
 
     // If this group exists already
     const group = policy.groups.find((g: Group) => g.name == groupSummary.name);
     if (group) {
-        logger.error(`Group ${groupSummary.name} exists already for policy: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Group ${groupSummary.name} exists already for policy: ${policyName}`);
     }
 
     // Then add the group to the policy
@@ -48,5 +44,4 @@ export async function addGroupToPolicyHandler(groupName: string, policyName: str
     await editPolicy(policy, policyHttpService);
 
     logger.info(`Added ${groupName} to ${policyName} policy!`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-group/delete-group-policy-handler.ts
+++ b/src/handlers/policy/policy-group/delete-group-policy-handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { OrganizationHttpService } from '../../../http-services/organization/organization.http-services';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 import { editPolicy, getPolicyFromName } from '../../../../src/services/policy/policy.services';
@@ -11,8 +10,7 @@ export async function deleteGroupFromPolicyHandler(groupName: string, policyName
     const groups = await organizationHttpService.ListGroups();
     const groupSummary = groups.find(g => g.name == groupName);
     if (groupSummary == undefined) {
-        logger.error(`Unable to find group with name: ${groupName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find group with name: ${groupName}`);
     }
 
     const policyHttpService = new PolicyHttpService(configService, logger);
@@ -20,14 +18,12 @@ export async function deleteGroupFromPolicyHandler(groupName: string, policyName
 
     if (policy === null) {
         // Log an error
-        logger.error(`Unable to find policy with name: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find policy with name: ${policyName}`);
     }
 
     // If this group does not exist in this policy
     if (!policy.groups.find(g => g.name == groupSummary.name)) {
-        logger.error(`Group ${groupName} does not exist for policy: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Group ${groupName} does not exist for policy: ${policyName}`);
     }
 
     // Then delete the group from the policy
@@ -37,5 +33,4 @@ export async function deleteGroupFromPolicyHandler(groupName: string, policyName
     await editPolicy(policy, policyHttpService);
 
     logger.info(`Deleted ${groupName} from ${policyName} policy!`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-group/list-groups.handler.ts
+++ b/src/handlers/policy/policy-group/list-groups.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { getTableOfGroups } from '../../../utils/utils';
 import yargs from 'yargs';
 import { listGroupArgs } from './list-groups.command-builder';
@@ -19,12 +18,10 @@ export async function listGroupsHandler(
     } else {
         if (groups.length === 0){
             logger.info('There are no available groups');
-            await cleanExit(0, logger);
+            return;
         }
         // regular table output
         const tableString = getTableOfGroups(groups);
         console.log(tableString);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-list/list-policies.handler.ts
+++ b/src/handlers/policy/policy-list/list-policies.handler.ts
@@ -7,7 +7,6 @@ import { listKubernetesPoliciesHandler } from './list-kubernetes-policies.handle
 import { listSessionRecordingPoliciesHandler } from './list-session-recording-policies.handler';
 import { listProxyPoliciesHandler } from './list-proxy-policies.handler';
 import { listOrganizationControlsPoliciesHandler } from './list-organization-controls-policies.handler';
-import { cleanExit } from '../../clean-exit.handler';
 import { parsePolicyType } from '../../../utils/utils';
 
 import yargs from 'yargs';
@@ -76,7 +75,6 @@ export async function listPoliciesHandler(
         printPolicyHelper(argv, orgControlPolicies, PolicyType.OrganizationControls, logger);
         break;
     }
-    await cleanExit(0, logger);
 }
 
 // Helper function to abstract printing to console

--- a/src/handlers/policy/policy-service-account/list-service-accounts.handler.ts
+++ b/src/handlers/policy/policy-service-account/list-service-accounts.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { getTableOfServiceAccounts } from '../../../utils/utils';
 import yargs from 'yargs';
 import { listServiceAccountsArgs } from './list-service-accounts.command-builder';
@@ -19,12 +18,10 @@ export async function listServiceAccountsHandler(
     } else {
         if (serviceAccounts.length === 0){
             logger.info('There are no available service accounts');
-            await cleanExit(0, logger);
+            return;
         }
         // regular table output
         const tableString = getTableOfServiceAccounts(serviceAccounts, !!argv.detail);
         console.log(tableString);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-targetgroup/add-targetgroup-policy.handler.ts
+++ b/src/handlers/policy/policy-targetgroup/add-targetgroup-policy.handler.ts
@@ -2,7 +2,6 @@ import { ClusterGroup } from '../../../../webshell-common-ts/http/v2/policy/type
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 
 export async function addTargetGroupToPolicyHandler(targetGroupName: string, policyName: string, configService: ConfigService, logger: Logger) {
     // First get the existing policy
@@ -14,14 +13,12 @@ export async function addTargetGroupToPolicyHandler(targetGroupName: string, pol
 
     if (!kubePolicy) {
         // Log an error
-        logger.error(`Unable to find Kubernetes Tunnel policy with name: ${policyName}. Please make sure ${policyName} is a Kubernetes Tunnel policy.`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find Kubernetes Tunnel policy with name: ${policyName}. Please make sure ${policyName} is a Kubernetes Tunnel policy.`);
     }
 
     // If this cluster Group exists already
     if (kubePolicy.clusterGroups.find(g => g.name === targetGroupName)) {
-        logger.error(`Group ${targetGroupName} exists already for policy: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Group ${targetGroupName} exists already for policy: ${policyName}`);
     }
 
     // Then add the clusterGroup to the policy
@@ -35,5 +32,4 @@ export async function addTargetGroupToPolicyHandler(targetGroupName: string, pol
     await policyHttpService.EditKubernetesPolicy(kubePolicy);
 
     logger.info(`Added ${targetGroupName} to ${policyName} policy!`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-targetgroup/delete-targetgroup-policy.handler.ts
+++ b/src/handlers/policy/policy-targetgroup/delete-targetgroup-policy.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 
 export async function deleteTargetGroupFromPolicyHandler(targetGroupName: string, policyName: string, configService: ConfigService, logger: Logger) {
@@ -13,14 +12,12 @@ export async function deleteTargetGroupFromPolicyHandler(targetGroupName: string
 
     if (!kubePolicy) {
         // Log an error
-        logger.error(`Unable to find Kubernetes Tunnel policy with name: ${policyName}. Please make sure ${policyName} is a Kubernetes Tunnel policy.`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find Kubernetes Tunnel policy with name: ${policyName}. Please make sure ${policyName} is a Kubernetes Tunnel policy.`);
     }
 
     // Now check if the group exists
     if (!kubePolicy.clusterGroups.find(g => g.name === targetGroupName)) {
-        logger.error(`No group ${targetGroupName} exists for policy: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`No group ${targetGroupName} exists for policy: ${policyName}`);
     }
 
     // And finally update the policy
@@ -29,6 +26,5 @@ export async function deleteTargetGroupFromPolicyHandler(targetGroupName: string
     await policyHttpService.EditKubernetesPolicy(kubePolicy);
 
     logger.info(`Deleted ${targetGroupName} from ${policyName} policy!`);
-    await cleanExit(0, logger);
 }
 

--- a/src/handlers/policy/policy-targetgroup/list-targetgroups.handler.ts
+++ b/src/handlers/policy/policy-targetgroup/list-targetgroups.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../../services/logger/logger.service';
 import { ConfigService } from '../../../services/config/config.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { getTableOfTargetGroups } from '../../../utils/utils';
 import yargs from 'yargs';
 import { listTargetGroupArgs } from './list-targetgroups.command-builder';
@@ -24,12 +23,10 @@ export async function listTargetGroupsHandler(configService: ConfigService, logg
     } else {
         if (targetGroups.length === 0){
             logger.info('There are no available target groups');
-            await cleanExit(0, logger);
+            return;
         }
         // regular table output
         const tableString = getTableOfTargetGroups(targetGroups);
         console.log(tableString);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-targetuser/add-targetuser-policy.handler.ts
+++ b/src/handlers/policy/policy-targetuser/add-targetuser-policy.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 import { ClusterUser } from '../../../../webshell-common-ts/http/v2/policy/types/cluster-user.types';
 import { TargetUser } from '../../../../webshell-common-ts/http/v2/policy/types/target-user.types';
@@ -19,15 +18,13 @@ export async function addTargetUserToPolicyHandler(targetUserName: string, polic
 
     if (!kubePolicy && !targetPolicy && !proxyPolicy) {
         // Log an error
-        logger.error(`Unable to find policy with name: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find policy with name: ${policyName}`);
     }
 
     if (kubePolicy) {
         // If this cluster targetUser exists already
         if (kubePolicy.clusterUsers.find(u => u.name === targetUserName)) {
-            logger.error(`Target user ${targetUserName} exists already for policy: ${policyName}`);
-            await cleanExit(1, logger);
+            throw new Error(`Target user ${targetUserName} exists already for policy: ${policyName}`);
         }
 
         // Then add the targetUser to the policy
@@ -42,8 +39,7 @@ export async function addTargetUserToPolicyHandler(targetUserName: string, polic
     } else if (targetPolicy) {
         // If this targetUser exists already
         if (targetPolicy.targetUsers.find(u => u.userName === targetUserName)) {
-            logger.error(`Target user ${targetUserName} exists already for policy: ${policyName}`);
-            await cleanExit(1, logger);
+            throw new Error(`Target user ${targetUserName} exists already for policy: ${policyName}`);
         }
 
         // Then add the targetUser to the policy
@@ -57,8 +53,7 @@ export async function addTargetUserToPolicyHandler(targetUserName: string, polic
     } else if (proxyPolicy) {
         // If this targetUser exists already
         if (proxyPolicy.targetUsers.find(u => u.userName === targetUserName)) {
-            logger.error(`Target user ${targetUserName} exists already for policy: ${policyName}`);
-            await cleanExit(1, logger);
+            throw new Error(`Target user ${targetUserName} exists already for policy: ${policyName}`);
         }
 
         // Then add the targetUser to the policy
@@ -70,10 +65,8 @@ export async function addTargetUserToPolicyHandler(targetUserName: string, polic
         proxyPolicy.targetUsers.push(targetUserToAdd);
         await policyHttpService.EditProxyPolicy(proxyPolicy);
     } else {
-        logger.error(`Adding target user to policy ${policyName} failed. Adding target users to this policy type is not currently supported.`);
-        await cleanExit(1, logger);
+        throw new Error(`Adding target user to policy ${policyName} failed. Adding target users to this policy type is not currently supported.`);
     }
 
     logger.info(`Added ${targetUserName} to ${policyName} policy!`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-targetuser/list-targetusers.handler.ts
+++ b/src/handlers/policy/policy-targetuser/list-targetusers.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../../services/logger/logger.service';
 import { ConfigService } from '../../../services/config/config.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { getTableOfTargetUsers } from '../../../utils/utils';
 import yargs from 'yargs';
 import { listTargetUserArgs } from './list-targetusers.command-builder';
@@ -20,8 +19,7 @@ export async function listTargetUsersHandler(configService: ConfigService, logge
 
     if (!kubePolicy && !targetPolicy && !proxyPolicy) {
         // Log an error
-        logger.error(`Unable to find policy with name: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find policy with name: ${policyName}`);
     }
 
     const targetUsers : string[] = [];
@@ -45,12 +43,10 @@ export async function listTargetUsersHandler(configService: ConfigService, logge
     } else {
         if (targetUsers.length === 0){
             logger.info('There are no available target users');
-            await cleanExit(0, logger);
+            return;
         }
         // regular table output
         const tableString = getTableOfTargetUsers(targetUsers);
         console.log(tableString);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-user/add-user-policy.handler.ts
+++ b/src/handlers/policy/policy-user/add-user-policy.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { UserHttpService } from '../../../http-services/user/user.http-services';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
 import { UserSummary } from '../../../../webshell-common-ts/http/v2/user/types/user-summary.types';
@@ -16,8 +15,7 @@ export async function addUserToPolicyHandler(userEmail: string, policyName: stri
     try {
         userSummary = await userHttpService.GetUserByEmail(userEmail);
     } catch (error) {
-        logger.error(`Unable to find user with email: ${userEmail}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find user with email: ${userEmail}`);
 
     }
 
@@ -26,14 +24,12 @@ export async function addUserToPolicyHandler(userEmail: string, policyName: stri
 
     if (policy === null) {
         // Log an error
-        logger.error(`Unable to find policy with name: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find policy with name: ${policyName}`);
     }
 
     // If this user exists already
     if (policy.subjects.find(s => s.type === SubjectType.User && s.id === userSummary.id)) {
-        logger.error(`User ${userEmail} exists already for policy: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`User ${userEmail} exists already for policy: ${policyName}`);
     }
 
     // Then add the user to the policy
@@ -48,5 +44,4 @@ export async function addUserToPolicyHandler(userEmail: string, policyName: stri
     await editPolicy(policy, policyHttpService);
 
     logger.info(`Added ${userEmail} to ${policyName} policy!`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-user/delete-user-policy.handler.ts
+++ b/src/handlers/policy/policy-user/delete-user-policy.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { UserHttpService } from '../../../http-services/user/user.http-services';
 import { UserSummary } from '../../../../webshell-common-ts/http/v2/user/types/user-summary.types';
 import { PolicyHttpService } from '../../../http-services/policy/policy.http-services';
@@ -15,8 +14,7 @@ export async function deleteUserFromPolicyHandler(userEmail: string, policyName:
     try {
         userSummary = await userHttpService.GetUserByEmail(userEmail);
     } catch (error) {
-        logger.error(`Unable to find user with email: ${userEmail}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find user with email: ${userEmail}`);
 
     }
 
@@ -25,14 +23,12 @@ export async function deleteUserFromPolicyHandler(userEmail: string, policyName:
 
     if (!policy) {
         // Log an error
-        logger.error(`Unable to find policy with name: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find policy with name: ${policyName}`);
     }
 
     // If this user does not exist
     if (!policy.subjects.find(s => s.type === SubjectType.User && s.id === userSummary.id)) {
-        logger.error(`No user ${userEmail} exists for policy: ${policyName}`);
-        await cleanExit(1, logger);
+        throw new Error(`No user ${userEmail} exists for policy: ${policyName}`);
     }
 
     // And finally update the policy
@@ -40,5 +36,4 @@ export async function deleteUserFromPolicyHandler(userEmail: string, policyName:
     await editPolicy(policy, policyHttpService);
 
     logger.info(`Deleted ${userEmail} from ${policyName} policy!`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/policy/policy-user/list-users.handler.ts
+++ b/src/handlers/policy/policy-user/list-users.handler.ts
@@ -1,6 +1,5 @@
 import { ConfigService } from '../../../services/config/config.service';
 import { Logger } from '../../../services/logger/logger.service';
-import { cleanExit } from '../../clean-exit.handler';
 import { getTableOfUsers } from '../../../utils/utils';
 import yargs from 'yargs';
 import { listUserArgs } from './list-users.command-builder';
@@ -19,12 +18,10 @@ export async function listUsersHandler(
     } else {
         if (users.length === 0){
             logger.info('There are no available users');
-            await cleanExit(0, logger);
+            return;
         }
         // regular table output
         const tableString = getTableOfUsers(users);
         console.log(tableString);
     }
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/service-account/create-service-account.handler.ts
+++ b/src/handlers/service-account/create-service-account.handler.ts
@@ -1,6 +1,5 @@
 import { Logger } from '../../services/logger/logger.service';
 import { ConfigService } from '../../services/config/config.service';
-import { cleanExit } from '../clean-exit.handler';
 import yargs from 'yargs';
 import { ServiceAccountHttpService } from '../../http-services/service-account/service-account.http-services';
 import { createServiceAccountArgs } from '../../handlers/service-account/create-service-account.command-builder';
@@ -24,8 +23,7 @@ export async function createServiceAccountHandler(configService: ConfigService, 
     else {
         // If it is a generic service account, expect jwksUrl/Pattern to be provided
         if(!providerCredsFile.jwksURL || !providerCredsFile.jwksURLPattern) {
-            logger.error(`When creating a generic service account a jwksUrl and a jwksURLPattern need to be provider in the provider file.`);
-            await cleanExit(1, logger);
+            throw new Error(`When creating a generic service account a jwksUrl and a jwksURLPattern need to be provider in the provider file.`);
         }
         jwksURL = providerCredsFile.jwksURL;
     }
@@ -33,8 +31,7 @@ export async function createServiceAccountHandler(configService: ConfigService, 
     const serviceAccountEmailParts = providerCredsFile.client_email.split('@');
 
     if(serviceAccountEmailParts.length != 2){
-        logger.error(`The provided email ${providerCredsFile.client_email} is not a valid email.`);
-        await cleanExit(1, logger);
+        throw new Error(`The provided email ${providerCredsFile.client_email} is not a valid email.`);
     }
 
     // If this is a GCP service account construct the pattern, else use the provided one
@@ -52,6 +49,4 @@ export async function createServiceAccountHandler(configService: ConfigService, 
     logger.info(`Successfully created service account ${resp.serviceAccountSummary.email} with JWKS URL ${resp.serviceAccountSummary.jwksUrl}`);
     await createBzeroCredsFile(resp.mfaSecret, configService.me().organizationId, configService.getIdp(), argv.bzeroCreds);
     logger.info('Successfully created the BastionZero credentials of this service account');
-
-    await cleanExit(0, logger);
 }

--- a/src/handlers/service-account/disable-service-account.handler.ts
+++ b/src/handlers/service-account/disable-service-account.handler.ts
@@ -4,7 +4,6 @@ import { ServiceAccountHttpService } from '../../../src/http-services/service-ac
 import { Logger } from '../../../src/services/logger/logger.service';
 import { SubjectHttpService } from '../../../src/http-services/subject/subject.http-services';
 import { SubjectType } from '../../../webshell-common-ts/http/v2/common.types/subject.types';
-import { cleanExit } from '../clean-exit.handler';
 import { disableServiceAccountArgs } from './disable-service-account.command-builder';
 import { UpdateServiceAccountRequest } from '../../../webshell-common-ts/http/v2/service-account/requests/update-service-account.requests';
 import { SubjectSummary } from '../../../webshell-common-ts/http/v2/subject/types/subject-summary.types';
@@ -17,19 +16,16 @@ export async function disableServiceAccountHandler(configService: ConfigService,
     try {
         subjectSummary = await subjectHttpService.GetSubjectByEmail(argv.serviceAccountEmail);
     } catch (error) {
-        logger.error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
     }
 
     if(subjectSummary.type != SubjectType.ServiceAccount)
     {
-        logger.error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
-        await cleanExit(1, logger);
+        throw new Error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
     }
     const request: UpdateServiceAccountRequest = {
         enabled: false
     };
     const serviceAccount = await serviceAccountHttpService.UpdateServiceAccount(subjectSummary.id, request);
     logger.info(`Successfully disabled service account ${serviceAccount.email}`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/service-account/enable-service-account.handler.ts
+++ b/src/handlers/service-account/enable-service-account.handler.ts
@@ -4,7 +4,6 @@ import { ServiceAccountHttpService } from '../../../src/http-services/service-ac
 import { Logger } from '../../../src/services/logger/logger.service';
 import { SubjectHttpService } from '../../../src/http-services/subject/subject.http-services';
 import { SubjectType } from '../../../webshell-common-ts/http/v2/common.types/subject.types';
-import { cleanExit } from '../clean-exit.handler';
 import { enableServiceAccountArgs } from './enable-service-account.command-builder';
 import { UpdateServiceAccountRequest } from '../../../webshell-common-ts/http/v2/service-account/requests/update-service-account.requests';
 import { SubjectSummary } from '../../../webshell-common-ts/http/v2/subject/types/subject-summary.types';
@@ -17,19 +16,16 @@ export async function enableServiceAccountHandler(configService: ConfigService, 
     try {
         subjectSummary = await subjectHttpService.GetSubjectByEmail(argv.serviceAccountEmail);
     } catch (error) {
-        logger.error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
     }
 
     if(subjectSummary.type != SubjectType.ServiceAccount)
     {
-        logger.error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
-        await cleanExit(1, logger);
+        throw new Error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
     }
     const request: UpdateServiceAccountRequest = {
         enabled: true
     };
     const serviceAccount = await serviceAccountHttpService.UpdateServiceAccount(subjectSummary.id, request);
     logger.info(`Successfully enabled service account ${serviceAccount.email}`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/service-account/rotate-mfa.handler.ts
+++ b/src/handlers/service-account/rotate-mfa.handler.ts
@@ -5,7 +5,6 @@ import { Logger } from '../../../src/services/logger/logger.service';
 import { rotateMfaArgs } from './rotate-mfa.command-builder';
 import { SubjectHttpService } from '../../../src/http-services/subject/subject.http-services';
 import { SubjectType } from '../../../webshell-common-ts/http/v2/common.types/subject.types';
-import { cleanExit } from '../clean-exit.handler';
 import { MfaHttpService } from '../../../src/http-services/mfa/mfa.http-services';
 import { checkWritableFilePath, createBzeroCredsFile } from '../../../src/utils/utils';
 import { SubjectSummary } from '../../../webshell-common-ts/http/v2/subject/types/subject-summary.types';
@@ -21,19 +20,16 @@ export async function rotateMfaHandler(configService: ConfigService, logger: Log
     try {
         subjectSummary = await subjectHttpService.GetSubjectByEmail(argv.serviceAccountEmail);
     } catch (error) {
-        logger.error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
     }
 
     if(subjectSummary.type != SubjectType.ServiceAccount)
     {
-        logger.error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
-        await cleanExit(1, logger);
+        throw new Error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
     }
 
     const serviceAccount = await serviceAccountHttpService.GetServiceAccount(subjectSummary.id);
     const newMfaSecret = await mfaHttpService.RotateSecret(serviceAccount.id);
     await createBzeroCredsFile(newMfaSecret, configService.me().organizationId, configService.getIdp(), argv.bzeroCreds);
     logger.info(`Successfully rotated mfa secret and created new BastionZero credentials of service account ${serviceAccount.email}`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/service-account/set-role-service-account.handler.ts
+++ b/src/handlers/service-account/set-role-service-account.handler.ts
@@ -2,7 +2,6 @@ import { SubjectHttpService } from '../../../src/http-services/subject/subject.h
 import { ConfigService } from '../../../src/services/config/config.service';
 import { SubjectType } from '../../../webshell-common-ts/http/v2/common.types/subject.types';
 import yargs from 'yargs';
-import { cleanExit } from '../clean-exit.handler';
 import { Logger } from '../../../src/services/logger/logger.service';
 import { serviceAccountSetRoleArgs } from './set-role-service-account.command-builder';
 import { parseSubjectRole } from '../../../src/utils/utils';
@@ -15,13 +14,11 @@ export async function serviceAccountSetRoleCmdHandler(configService: ConfigServi
     try {
         subjectSummary = await subjectHttpService.GetSubjectByEmail(argv.serviceAccountEmail);
     } catch (error) {
-        logger.error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
-        await cleanExit(1, logger);
+        throw new Error(`Unable to find subject with email: ${argv.serviceAccountEmail}`);
     }
     if(subjectSummary.type != SubjectType.ServiceAccount)
     {
-        logger.error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
-        await cleanExit(1, logger);
+        throw new Error(`The provided subject ${argv.serviceAccountEmail} is not a service account.`);
     }
 
     const parsedSubjectRole = parseSubjectRole(argv.role);
@@ -29,12 +26,10 @@ export async function serviceAccountSetRoleCmdHandler(configService: ConfigServi
     if(subjectSummary.isAdmin &&  parsedSubjectRole === SubjectRole.Admin ||
        !subjectSummary.isAdmin && parsedSubjectRole === SubjectRole.User)
     {
-        logger.error(`The provided subject ${argv.serviceAccountEmail}'s role is already ${argv.role}.`);
-        await cleanExit(1, logger);
+        throw new Error(`The provided subject ${argv.serviceAccountEmail}'s role is already ${argv.role}.`);
     }
 
     await subjectHttpService.UpdateSubjectRole(subjectSummary.id, {role: parsedSubjectRole });
 
     logger.info(`Successfully updated role of service account ${subjectSummary.email}`);
-    await cleanExit(0, logger);
 }

--- a/src/handlers/target/target-restart.handler.ts
+++ b/src/handlers/target/target-restart.handler.ts
@@ -3,7 +3,6 @@ import { Logger } from '../../services/logger/logger.service';
 import { parseTargetString } from '../../utils/utils';
 import { restartArgs } from './target-restart.command-builder';
 import yargs from 'yargs';
-import { cleanExit } from '../clean-exit.handler';
 import { BzeroTargetHttpService } from '../../http-services/targets/bzero/bzero.http-services';
 
 export async function targetRestartHandler(
@@ -19,19 +18,12 @@ export async function targetRestartHandler(
 
     const bzeroTargetService = new BzeroTargetHttpService(configService, logger);
 
-    try {
-        await bzeroTargetService.RestartBzeroTarget({
-            targetName: parsedTarget.name,
-            targetId: parsedTarget.id,
-            envId: parsedTarget.envId,
-            envName: parsedTarget.envName,
-        });
-    } catch (error) {
-        logger.error(error);
-        await cleanExit(1, logger);
-    }
+    await bzeroTargetService.RestartBzeroTarget({
+        targetName: parsedTarget.name,
+        targetId: parsedTarget.id,
+        envId: parsedTarget.envId,
+        envName: parsedTarget.envName,
+    });
 
     logger.info(`Agent restart initiated. To monitor your target's status, use: zli lt -d${parsedTarget.name ? ` -n ${parsedTarget.name}` : ` -i`} `);
-
-    await cleanExit(0, logger);
 }


### PR DESCRIPTION
## Description of the change

Moving to a new Handler standard where we either throw or return in Handler functions and then either exit 0, or exit 1 and catch the error in `cli-driver`'s `run` function.

This also helps out with Windows, where the command will never exit unless we explicitly tell it to do so. This pattern will help ensure that is happening.

## Testing

Describe how to test this PR....

**backend branch:** 
**bzero branch:** 
**charts branch:** 

#### Ready to run system tests?

- [x] Yes

## Relevant release note information

Release Notes: No functionality changes

## Related JIRA tickets

Relates to JIRA: CWC-2573

## Relevant HotFix if applicable

Relevant HotFix PR Number:

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain:

Does this PR add a new/modifies the name/arguments of a `zli` command?

- [ ] Yes
- [x] No

If yes, please provide the docs/zli-reference-manual branch reflecting the changes:
